### PR TITLE
IdProduct on Add and Update product

### DIFF
--- a/ebay.php
+++ b/ebay.php
@@ -538,10 +538,10 @@ class Ebay extends Module
 	 **/
 	public function hookAddProduct($params)
 	{
-		if (!isset($params['product']->id))
+		if (!isset($params['id_product']))
 			return false;
 
-		if (!($id_product = (int)$params['product']->id))
+		if (!($id_product = (int)$params['id_product']))
 			return false;
 		
 		if ($this->is_multishop)
@@ -943,10 +943,10 @@ class Ebay extends Module
 	public function hookUpdateProduct($params)
 	{
 //		$this->hookAddProduct($params);
-		if (!isset($params['product']->id))
+		if (!isset($params['id_product']))
 			return false;
 
-		if (!($id_product = (int)$params['product']->id))
+		if (!($id_product = (int)$params['id_product']))
 			return false;
 		
 		if(!($this->ebay_profile instanceof EbayProfile))


### PR DESCRIPTION
On hook addProduct and updateProduct, there is no object "product" given
in $params ; only "id_product". So sync couldn't work on Prestashop 1.6.