### PR TITLE
Changes on paging webservices getOrders

### DIFF
--- a/ebay.php
+++ b/ebay.php
@@ -921,7 +921,7 @@ class Ebay extends Module
 		$orders = array();
 		$nb_page_orders = 100;
 
-		while ($nb_page_orders == 100 && $page < 10)
+		while ($nb_page_orders > 0 && $page < 10)
 		{
 			$page_orders = array();
 			foreach ($ebay->getOrders($from_date, $until_date, $page) as $order_xml)

--- a/ebay.php
+++ b/ebay.php
@@ -538,10 +538,10 @@ class Ebay extends Module
 	 **/
 	public function hookAddProduct($params)
 	{
-		if (!isset($params['product']->id))
+		if (!isset($params['id_product']))
 			return false;
 
-		if (!($id_product = (int)$params['product']->id))
+		if (!($id_product = (int)$params['id_product']))
 			return false;
 		
 		if ($this->is_multishop)
@@ -943,10 +943,10 @@ class Ebay extends Module
 	public function hookUpdateProduct($params)
 	{
 //		$this->hookAddProduct($params);
-		if (!isset($params['product']->id))
+		if (!isset($params['id_product']))
 			return false;
 
-		if (!($id_product = (int)$params['product']->id))
+		if (!($id_product = (int)$params['id_product']))
 			return false;
 		
 		if(!($this->ebay_profile instanceof EbayProfile))


### PR DESCRIPTION
There is a bug with your pager detecting method on _getLastOrders from Ebay Webservice.
You are testing if 100 orders are in the current page, then if yes, you call next page.
But, if you have a error on orders on the first page which should contains 100 orders, in fact, Ebay returns 100 order less the number of orders in error. 
And then, your testing method say there are no more pages...

So, I've changed it testing only on existence of orders in the page returned. This will cause one more call to check if next one is empty or not.