### PR TITLE
Update getProducts.php

### DIFF
--- a/ajax/getProducts.php
+++ b/ajax/getProducts.php
@@ -58,7 +58,7 @@ if ($is_one_five) {
 		
 	$sql .= ' product_shop.`id_shop` = 1 AND ';
 	$sql .= ' p.`id_category_default` = '.(int)Tools::getValue('category');
-	$sql .= $ebay->addSqlRestrictionOnLang('sa');
+	$sql .= $ebay->addSqlRestrictionOnLang('pl');
 	
 } else {
 	


### PR DESCRIPTION
Hello,

I think that here 
    $sql .= $ebay->addSqlRestrictionOnLang('sa');

better with

$sql .= $ebay->addSqlRestrictionOnLang('pl');

because with one warehouse and 2 multishops in _stock_available we never have  id_shop = 1

and when we go into the "category tab / show categories" and we click on showproducts there are no products displayed

best regards
marius
