### PR TITLE
Quantity restrictions on items posted to ebay.

### DIFF
--- a/ajax/checkDatabase.php
+++ b/ajax/checkDatabase.php
@@ -29,7 +29,7 @@ if (!defined('TMP_DS')) {
 }
 
 require_once dirname(__FILE__).TMP_DS.'..'.TMP_DS.'..'.TMP_DS.'..'.TMP_DS.'config'.TMP_DS.'config.inc.php';
-require_once dirname(__FILE__).TMP_DS.'..'.TMP_DS.'..'.TMP_DS.'..'.TMP_DS.'init.php';
+include_once dirname(__FILE__).TMP_DS.'..'.TMP_DS.'..'.TMP_DS.'..'.TMP_DS.'init.php';
 
 if (!Configuration::get('EBAY_SECURITY_TOKEN') || Tools::getValue('token') != Configuration::get('EBAY_SECURITY_TOKEN')) {
     die('INVALID TOKEN');

--- a/ajax/deleteOrphanListing.php
+++ b/ajax/deleteOrphanListing.php
@@ -29,7 +29,7 @@ if (!defined('TMP_DS')) {
 }
 
 require_once dirname(__FILE__).TMP_DS.'..'.TMP_DS.'..'.TMP_DS.'..'.TMP_DS.'config'.TMP_DS.'config.inc.php';
-require_once dirname(__FILE__).TMP_DS.'..'.TMP_DS.'..'.TMP_DS.'..'.TMP_DS.'init.php';
+include_once dirname(__FILE__).TMP_DS.'..'.TMP_DS.'..'.TMP_DS.'..'.TMP_DS.'init.php';
 include '../ebay.php';
 
 $ebay = new Ebay();

--- a/ajax/deleteProfile.php
+++ b/ajax/deleteProfile.php
@@ -34,7 +34,7 @@ if (!Tools::getValue('token') || Tools::getValue('token') != Configuration::get(
     die('ERROR: Invalid Token');
 }
 
-require_once dirname(__FILE__).TMP_DS.'..'.TMP_DS.'..'.TMP_DS.'..'.TMP_DS.'init.php';
+include_once dirname(__FILE__).TMP_DS.'..'.TMP_DS.'..'.TMP_DS.'..'.TMP_DS.'init.php';
 
 if (Module::isInstalled('ebay')) {
     $ebay = Module::getInstanceByName('ebay');

--- a/ajax/eBaySyncProduct.php
+++ b/ajax/eBaySyncProduct.php
@@ -38,9 +38,9 @@ if (EbayTools::getValue('admin_path')) {
 require_once dirname(__FILE__).TMP_DS.'..'.TMP_DS.'..'.TMP_DS.'..'.TMP_DS.'config'.TMP_DS.'config.inc.php';
 
 if (version_compare(_PS_VERSION_, '1.5', '>')) {
-    require_once _PS_ADMIN_DIR_.'init.php';
+    include_once _PS_ADMIN_DIR_.'init.php';
 } else {
-    require_once dirname(__FILE__).TMP_DS.'..'.TMP_DS.'..'.TMP_DS.'..'.TMP_DS.'init.php';
+    include_once dirname(__FILE__).TMP_DS.'..'.TMP_DS.'..'.TMP_DS.'..'.TMP_DS.'init.php';
 }
 
 if (!Tools::getValue('token')

--- a/ajax/getNbProductsSync.php
+++ b/ajax/getNbProductsSync.php
@@ -41,6 +41,11 @@ $ebay_profile = new EbayProfile($id_ebay_profile);
 
 Db::getInstance()->autoExecute(_DB_PREFIX_.'ebay_category_configuration', array('sync' => (int) Tools::getValue('action')), 'UPDATE', '`id_category` = '.(int) Tools::getValue('id_category').' AND `id_ebay_profile` = '.(int) $ebay_profile->id);
 
+if ( ($minqty = $ebay_profile->getConfiguration('EBAY_MINQTY')) == null) {
+	$minqty = 0;
+}
+
+
 if (version_compare(_PS_VERSION_, '1.5', '>')) {
     $sql = 'SELECT COUNT(*) AS nb FROM(
         SELECT p.id_product
@@ -53,7 +58,7 @@ if (version_compare(_PS_VERSION_, '1.5', '>')) {
         AND ps.id_shop = '.(int) $ebay_profile->id_shop.'
         AND ps.active = 1';
 
-    $sql .= ' WHERE s.`quantity` > 0
+    $sql .= ' WHERE s.`quantity` > ' . $minqty . '
         AND p.`id_category_default` IN (
             SELECT `id_category`
             FROM `'._DB_PREFIX_.'ebay_category_configuration`
@@ -65,7 +70,7 @@ if (version_compare(_PS_VERSION_, '1.5', '>')) {
 } else {
     $sql = 'SELECT COUNT(`id_product`) as nb
         FROM `'._DB_PREFIX_.'product` AS p
-        WHERE p.`quantity` > 0
+        WHERE p.`quantity` > ' . $minqty . '
         AND p.`active` = 1
         AND p.`id_category_default` IN (
             SELECT `id_category`

--- a/ajax/loadCategoriesFromEbay.php
+++ b/ajax/loadCategoriesFromEbay.php
@@ -38,9 +38,9 @@ if (EbayTools::getValue('admin_path')) {
 require_once dirname(__FILE__).TMP_DS.'..'.TMP_DS.'..'.TMP_DS.'..'.TMP_DS.'config'.TMP_DS.'config.inc.php';
 
 if (version_compare(_PS_VERSION_, '1.5', '>')) {
-    require_once _PS_ADMIN_DIR_.'init.php';
+    include_once _PS_ADMIN_DIR_.'init.php';
 } else {
-    require_once dirname(__FILE__).TMP_DS.'..'.TMP_DS.'..'.TMP_DS.'..'.TMP_DS.'init.php';
+    include_once dirname(__FILE__).TMP_DS.'..'.TMP_DS.'..'.TMP_DS.'..'.TMP_DS.'init.php';
 }
 
 if (!Tools::getValue('token')

--- a/ajax/saveCategories.php
+++ b/ajax/saveCategories.php
@@ -25,7 +25,7 @@
  */
 
 include dirname(__FILE__).'/../../../config/config.inc.php';
-require_once dirname(__FILE__).'/../../../init.php';
+include_once dirname(__FILE__).'/../../../init.php';
 include '../ebay.php';
 
 if (!Tools::getValue('token') || Tools::getValue('token') != Configuration::get('EBAY_SECURITY_TOKEN')) {

--- a/classes/EbayCategory.php
+++ b/classes/EbayCategory.php
@@ -18,10 +18,10 @@
  * versions in the future. If you wish to customize PrestaShop for your
  * needs please refer to http://www.prestashop.com for more information.
  *
- *  @author    PrestaShop SA <contact@prestashop.com>
- *  @copyright 2007-2016 PrestaShop SA
- *  @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
- *  International Registered Trademark & Property of PrestaShop SA
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2016 PrestaShop SA
+ * @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
  */
 
 class EbayCategory
@@ -42,14 +42,14 @@ class EbayCategory
     {
         if ($ebay_profile) {
             $this->ebay_profile = $ebay_profile;
-            $this->id_country = (int) $ebay_profile->ebay_site_id;
+            $this->id_country = (int)$ebay_profile->ebay_site_id;
         }
         if ($id_category_ref) {
-            $this->id_category_ref = (int) $id_category_ref;
+            $this->id_category_ref = (int)$id_category_ref;
         }
 
         if ($id_category) {
-            $this->id_category = (int) $id_category;
+            $this->id_category = (int)$id_category;
         }
 
     }
@@ -59,13 +59,13 @@ class EbayCategory
         $sql = 'SELECT ecc.`id_category`, ec.`id_category_ref`, ec.`is_multi_sku`, ecc.`percent` FROM `'._DB_PREFIX_.'ebay_category` ec
 			LEFT JOIN `'._DB_PREFIX_.'ebay_category_configuration` ecc
 			ON (ecc.`id_ebay_category` = ec.`id_ebay_category`)
-			AND ecc.`id_ebay_profile` = '.(int) $this->ebay_profile->id.'
-			WHERE ec.`id_country` = '.(int) $this->id_country.' AND ';
+			AND ecc.`id_ebay_profile` = '.(int)$this->ebay_profile->id.'
+			WHERE ec.`id_country` = '.(int)$this->id_country.' AND ';
 
         if ($this->id_category_ref) {
-            $sql .= 'ec.`id_category_ref` = '.(int) $this->id_category_ref;
+            $sql .= 'ec.`id_category_ref` = '.(int)$this->id_category_ref;
         } else {
-            $sql .= 'ecc.`id_category` = '.(int) $this->id_category;
+            $sql .= 'ecc.`id_category` = '.(int)$this->id_category;
         }
 
         $res = Db::getInstance()->getRow($sql);
@@ -92,7 +92,7 @@ class EbayCategory
         }
 
         if ($this->is_multi_sku === null) {
-            $this->is_multi_sku = EbayCategory::getInheritedIsMultiSku((int) $this->id_category_ref, $this->id_country);
+            $this->is_multi_sku = EbayCategory::getInheritedIsMultiSku((int)$this->id_category_ref, $this->id_country);
         }
 
         return $this->is_multi_sku;
@@ -107,9 +107,8 @@ class EbayCategory
         return $this->percent;
     }
 
-    /*
+    /**
      * returns the percent, without the percent sign if there is one
-     *
      */
     public function getCleanPercent()
     {
@@ -117,24 +116,20 @@ class EbayCategory
     }
 
     /**
-     *
      * Returns the items specifics with the PrestaShop attribute group / feature / of eBay specifics matching
-     *
      */
     public function getItemsSpecifics()
     {
-        $sql = 'SELECT e.`name`, e.`id_ebay_category_specific` as id, e.`required`, e.`selection_mode`, e.`id_attribute_group`, e.`id_feature`, e.`id_ebay_category_specific_value` as id_specific_value, e.`is_brand`, e.`can_variation`
+        $sql = 'SELECT e.`name`, e.`id_ebay_category_specific` as id, e.`required`, e.`selection_mode`, e.`id_attribute_group`, e.`id_feature`, e.`id_ebay_category_specific_value` as id_specific_value, e.`is_brand`, e.`can_variation`, e.`is_reference`, e.`is_ean`, e.`is_upc`
 			FROM `'._DB_PREFIX_.'ebay_category_specific` e
-			WHERE e.`id_category_ref` = '.(int) $this->id_category_ref.'
-			AND e.`ebay_site_id` = '.(int) $this->id_country;
+			WHERE e.`id_category_ref` = '.(int)$this->id_category_ref.'
+			AND e.`ebay_site_id` = '.(int)$this->id_country;
 
         return DB::getInstance()->executeS($sql);
     }
 
     /**
-     *
      * Returns the items specifics with the full value for ebay_specific_attributes
-     *
      */
     public function getItemsSpecificValues()
     {
@@ -143,12 +138,13 @@ class EbayCategory
                 $this->_loadFromDb();
             }
 
-            $sql = 'SELECT e.`name`, e.`can_variation`, e.`id_attribute_group`, e.`id_feature`, ec.`value` AS specific_value, e.`is_brand`
+            $sql = 'SELECT e.`name`, e.`can_variation`, e.`id_attribute_group`, e.`id_feature`,
+                ec.`value` AS specific_value, e.`is_brand`, e.`is_reference`, e.`is_ean`, e.`is_upc`
 				FROM `'._DB_PREFIX_.'ebay_category_specific` e
 				LEFT JOIN `'._DB_PREFIX_.'ebay_category_specific_value` ec
 				ON e.`id_ebay_category_specific_value` = ec.`id_ebay_category_specific_value`
-				WHERE e.`id_category_ref` = '.(int) $this->id_category_ref.'
-				AND e.`ebay_site_id` = '.(int) $this->id_country;
+				WHERE e.`id_category_ref` = '.(int)$this->id_category_ref.'
+				AND e.`ebay_site_id` = '.(int)$this->id_country;
 
             $this->items_specific_values = Db::getInstance()->executeS($sql);
         }
@@ -157,9 +153,10 @@ class EbayCategory
     }
 
     /**
-     *
      * Returns the category conditions with the corresponding types on PrestaShop if set
-     *
+     * @param int $id_ebay_profile
+     * @return array
+     * @throws PrestaShopDatabaseException
      */
     public function getConditionsWithConfiguration($id_ebay_profile)
     {
@@ -169,8 +166,8 @@ class EbayCategory
 			ON e.`id_category_ref` = ec.`id_category_ref`
 			AND e.`id_condition_ref` = ec.`id_condition_ref`
 			AND e.`id_ebay_profile` = ec.`id_ebay_profile`
-			WHERE e.`id_category_ref` = '.(int) $this->id_category_ref.'
-			AND e.`id_ebay_profile` = '.(int) $id_ebay_profile;
+			WHERE e.`id_category_ref` = '.(int)$this->id_category_ref.'
+			AND e.`id_ebay_profile` = '.(int)$id_ebay_profile;
 
         $res = Db::getInstance()->executeS($sql);
 
@@ -179,7 +176,7 @@ class EbayCategory
         foreach ($res as $row) {
             if (!isset($ret[$row['id']])) {
                 $ret[$row['id']] = array(
-                    'name' => $row['name'],
+                    'name'  => $row['name'],
                     'types' => array($row['type']),
                 );
             } else {
@@ -192,23 +189,24 @@ class EbayCategory
     }
 
     /**
-     *
      * Returns an array with the condition_type and corresponding ConditionID on eBay
-     *
+     * @param int $id_ebay_profile
+     * @return
+     * @throws PrestaShopDatabaseException
      */
     public function getConditionsValues($id_ebay_profile)
     {
         if (!isset($this->conditions_values[$id_ebay_profile])) {
             $sql = 'SELECT e.condition_type, e.id_condition_ref as condition_id
 				FROM '._DB_PREFIX_.'ebay_category_condition_configuration e
-				WHERE e.`id_ebay_profile` = '.(int) $id_ebay_profile.'
-				AND e.id_category_ref = '.(int) $this->id_category_ref;
+				WHERE e.`id_ebay_profile` = '.(int)$id_ebay_profile.'
+				AND e.id_category_ref = '.(int)$this->id_category_ref;
 
             $res = Db::getInstance()->executeS($sql);
 
             $ret = array(
-                'new' => null,
-                'used' => null,
+                'new'         => null,
+                'used'        => null,
                 'refurbished' => null,
             );
 
@@ -224,8 +222,9 @@ class EbayCategory
 
     public static function deleteCategoriesByIdCountry($id_country)
     {
-        return Db::getInstance()->Execute('DELETE FROM `'._DB_PREFIX_.'ebay_category` WHERE `id_country` = '.(int) $id_country);
+        return Db::getInstance()->Execute('DELETE FROM `'._DB_PREFIX_.'ebay_category` WHERE `id_country` = '.(int)$id_country);
     }
+
     public static function insertCategories($ebay_site_id, $categories, $categories_multi_sku)
     {
         $db = Db::getInstance();
@@ -233,13 +232,14 @@ class EbayCategory
         foreach ($categories as $category) {
             if (version_compare(_PS_VERSION_, '1.5', '<')) {
                 if (!$db->autoExecuteWithNullValues(_DB_PREFIX_.'ebay_category', array(
-                    'id_category_ref' => pSQL($category['CategoryID']),
+                    'id_category_ref'        => pSQL($category['CategoryID']),
                     'id_category_ref_parent' => pSQL($category['CategoryParentID']),
-                    'id_country' => pSQL($ebay_site_id),
-                    'level' => pSQL($category['CategoryLevel']),
-                    'is_multi_sku' => isset($categories_multi_sku[$category['CategoryID']]) ? pSQL($categories_multi_sku[$category['CategoryID']]) : null,
-                    'name' => pSQL($category['CategoryName']),
-                ), 'INSERT', '', 0)) {
+                    'id_country'             => pSQL($ebay_site_id),
+                    'level'                  => pSQL($category['CategoryLevel']),
+                    'is_multi_sku'           => isset($categories_multi_sku[$category['CategoryID']]) ? pSQL($categories_multi_sku[$category['CategoryID']]) : null,
+                    'name'                   => pSQL($category['CategoryName']),
+                ), 'INSERT', '', 0)
+                ) {
 
                     $handle = fopen(dirname(__FILE__).'/../log/import_category_ebay.txt', 'a+');
                     fwrite($handle, print_r($category, true));
@@ -250,13 +250,14 @@ class EbayCategory
                 }
             } else {
                 if (!$db->autoExecute(_DB_PREFIX_.'ebay_category', array(
-                    'id_category_ref' => pSQL($category['CategoryID']),
+                    'id_category_ref'        => pSQL($category['CategoryID']),
                     'id_category_ref_parent' => pSQL($category['CategoryParentID']),
-                    'id_country' => pSQL($ebay_site_id),
-                    'level' => pSQL($category['CategoryLevel']),
-                    'is_multi_sku' => isset($categories_multi_sku[$category['CategoryID']]) ? (int) $categories_multi_sku[$category['CategoryID']] : null,
-                    'name' => pSQL($category['CategoryName']),
-                ), 'INSERT', '', 0, true, true)) {
+                    'id_country'             => pSQL($ebay_site_id),
+                    'level'                  => pSQL($category['CategoryLevel']),
+                    'is_multi_sku'           => isset($categories_multi_sku[$category['CategoryID']]) ? (int)$categories_multi_sku[$category['CategoryID']] : null,
+                    'name'                   => pSQL($category['CategoryName']),
+                ), 'INSERT', '', 0, true, true)
+                ) {
 
                     $handle = fopen(dirname(__FILE__).'/../log/import_category_ebay.txt', 'a+');
                     fwrite($handle, print_r($category, true));
@@ -278,29 +279,31 @@ class EbayCategory
 
         foreach ($categories as $category) {
             $db->autoExecute(_DB_PREFIX_.'ebay_category', array(
-                'is_multi_sku' => isset($categories_multi_sku[$category['id_category_ref']]) ? (int) $categories_multi_sku[$category['id_category_ref']] : null,
-            ), 'UPDATE', '`id_category_ref` = '.(int) $category['id_category_ref'], 0, true, true);
+                'is_multi_sku' => isset($categories_multi_sku[$category['id_category_ref']]) ? (int)$categories_multi_sku[$category['id_category_ref']] : null,
+            ), 'UPDATE', '`id_category_ref` = '.(int)$category['id_category_ref'], 0, true, true);
         }
 
         Configuration::updateValue('EBAY_CATEGORY_MULTI_SKU_UPDATE', 1, false, 0, 0);
     }
 
-    /*
+    /**
      * Climbs up the categories hierarchy until finding the value inherited for is_multi_sku
-     *
+     * @param int $id_category_ref
+     * @param int $ebay_site_id
+     * @return
      */
     public static function getInheritedIsMultiSku($id_category_ref, $ebay_site_id)
     {
         $row = Db::getInstance()->getRow('SELECT `id_category_ref_parent`, `is_multi_sku`
 			FROM `'._DB_PREFIX_.'ebay_category`
-			WHERE `id_category_ref` = '.(int) $id_category_ref.'
-			AND `id_country` = '.(int) $ebay_site_id);
+			WHERE `id_category_ref` = '.(int)$id_category_ref.'
+			AND `id_country` = '.(int)$ebay_site_id);
 
         if ($row['is_multi_sku'] !== null) {
             return $row['is_multi_sku'];
         }
 
-        if ((int) $row['id_category_ref_parent'] != (int) $id_category_ref) {
+        if ((int)$row['id_category_ref_parent'] != (int)$id_category_ref) {
             return EbayCategory::getInheritedIsMultiSku($row['id_category_ref_parent'], $ebay_site_id);
         }
 
@@ -309,7 +312,7 @@ class EbayCategory
 
     public static function areCategoryLoaded($ebay_site_id)
     {
-        if (Db::getInstance()->getValue('SELECT COUNT(*) FROM '._DB_PREFIX_.'ebay_category ec WHERE ec.`id_country` = '.(int) $ebay_site_id) == 0) {
+        if (Db::getInstance()->getValue('SELECT COUNT(*) FROM '._DB_PREFIX_.'ebay_category ec WHERE ec.`id_country` = '.(int)$ebay_site_id) == 0) {
             return false;
         }
 

--- a/classes/EbayCategoryCondition.php
+++ b/classes/EbayCategoryCondition.php
@@ -21,7 +21,7 @@
  * @author    PrestaShop SA <contact@prestashop.com>
  * @copyright 2007-2016 PrestaShop SA
  * @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
- *  International Registered Trademark & Property of PrestaShop SA
+ * International Registered Trademark & Property of PrestaShop SA
  */
 
 if (file_exists(dirname(__FILE__).'/EbayRequest.php')) {
@@ -31,9 +31,12 @@ if (file_exists(dirname(__FILE__).'/EbayRequest.php')) {
 class EbayCategoryCondition
 {
     /**
-     *
      * Parse the data returned by the API for the eBay Category Conditions
-     **/
+     * @param int  $id_ebay_profile
+     * @param bool $id_category
+     * @return bool
+     * @throws PrestaShopDatabaseException
+     */
     public static function loadCategoryConditions($id_ebay_profile, $id_category = false)
     {
         $request = new EbayRequest($id_ebay_profile);
@@ -80,8 +83,8 @@ class EbayCategoryCondition
             Db::getInstance()->ExecuteS("SELECT 1");
         }
 
-        if ($conditions) // security to make sure there are values to enter befor truncating the table
-        {
+        // security to make sure there are values to enter befor truncating the table
+        if ($conditions) {
             $db = Db::getInstance();
             if (!$id_category) {
                 $db->Execute('DELETE FROM '._DB_PREFIX_.'ebay_category_condition
@@ -105,5 +108,4 @@ class EbayCategoryCondition
 
         return false;
     }
-
 }

--- a/classes/EbayCategoryConditionConfiguration.php
+++ b/classes/EbayCategoryConditionConfiguration.php
@@ -18,10 +18,10 @@
  * versions in the future. If you wish to customize PrestaShop for your
  * needs please refer to http://www.prestashop.com for more information.
  *
- *  @author    PrestaShop SA <contact@prestashop.com>
- *  @copyright 2007-2016 PrestaShop SA
- *  @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
- *  International Registered Trademark & Property of PrestaShop SA
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2016 PrestaShop SA
+ * @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
  */
 
 class EbayCategoryConditionConfiguration
@@ -33,8 +33,8 @@ class EbayCategoryConditionConfiguration
     public static function getPSConditions($condition_type = null)
     {
         $condition_types = array(
-            EbayCategoryConditionConfiguration::PS_CONDITION_NEW => 'new',
-            EbayCategoryConditionConfiguration::PS_CONDITION_USED => 'used',
+            EbayCategoryConditionConfiguration::PS_CONDITION_NEW         => 'new',
+            EbayCategoryConditionConfiguration::PS_CONDITION_USED        => 'used',
             EbayCategoryConditionConfiguration::PS_CONDITION_REFURBISHED => 'refurbished',
         );
 
@@ -57,6 +57,5 @@ class EbayCategoryConditionConfiguration
         } else {
             Db::getInstance()->execute('REPLACE INTO `'._DB_PREFIX_.'ebay_category_condition_configuration` (`'.implode('` , `', array_keys($to_insert)).'`) VALUES (\''.implode('\', \'', $to_insert).'\')');
         }
-
     }
 }

--- a/classes/EbayCategoryConfiguration.php
+++ b/classes/EbayCategoryConfiguration.php
@@ -18,10 +18,10 @@
  * versions in the future. If you wish to customize PrestaShop for your
  * needs please refer to http://www.prestashop.com for more information.
  *
- *  @author    PrestaShop SA <contact@prestashop.com>
- *  @copyright 2007-2016 PrestaShop SA
- *  @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
- *  International Registered Trademark & Property of PrestaShop SA
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2016 PrestaShop SA
+ * @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
  */
 
 class EbayCategoryConfiguration
@@ -32,8 +32,9 @@ class EbayCategoryConfiguration
      * Will only retrieve categories that have an Ebay equivalent
      * Depends on the sync mode
      *
-     * @param array $params hook parameters
-     **/
+     * @param EbayProfile $ebay_profile
+     * @return string
+     */
     public static function getCategoriesQuery($ebay_profile)
     {
         $sync_mode = $ebay_profile->getConfiguration('EBAY_SYNC_PRODUCTS_MODE');
@@ -42,7 +43,7 @@ class EbayCategoryConfiguration
 				FROM `'._DB_PREFIX_.'ebay_category_configuration`
 				WHERE `id_category` > 0
 				AND `id_ebay_category` > 0
-				AND `id_ebay_profile` = '.(int) $ebay_profile->id;
+				AND `id_ebay_profile` = '.(int)$ebay_profile->id;
 
         if ($sync_mode == 'B') {
             $sql .= ' AND `sync` = 1';
@@ -53,7 +54,9 @@ class EbayCategoryConfiguration
 
     /**
      * Returns the product ids of all product for which the category is matched with an eBay category
-     *
+     * @param int $id_ebay_profile
+     * @return array
+     * @throws PrestaShopDatabaseException
      */
     public static function getAllProductIds($id_ebay_profile)
     {
@@ -63,7 +66,7 @@ class EbayCategoryConfiguration
 			IN (
 				SELECT e.`id_category`
 				FROM `'._DB_PREFIX_.'ebay_category_configuration` e
-				WHERE e.`id_ebay_profile` = '.(int) $id_ebay_profile.'
+				WHERE e.`id_ebay_profile` = '.(int)$id_ebay_profile.'
 			)');
 
         return array_map(array('EbayCategoryConfiguration', 'getAllProductIdsMap'), $res);
@@ -77,7 +80,10 @@ class EbayCategoryConfiguration
     /**
      * Returns the eBay category ids
      *
-     **/
+     * @param int $id_ebay_profile
+     * @return array
+     * @throws PrestaShopDatabaseException
+     */
     public static function getEbayCategoryIds($id_ebay_profile)
     {
         $sql = 'SELECT
@@ -85,7 +91,7 @@ class EbayCategoryConfiguration
 			FROM `'._DB_PREFIX_.'ebay_category_configuration` e
 			LEFT JOIN `'._DB_PREFIX_.'ebay_category` ec
 			ON e.`id_ebay_category` = ec.`id_ebay_category`
-			WHERE e.`id_ebay_profile` = '.(int) $id_ebay_profile.'
+			WHERE e.`id_ebay_profile` = '.(int)$id_ebay_profile.'
 			AND ec.`id_category_ref` is not null';
 
         $res = Db::getInstance()->executeS($sql);
@@ -101,7 +107,10 @@ class EbayCategoryConfiguration
     /**
      * Returns the eBay category id and the full name including the name of the parent and the grandparent category
      *
-     **/
+     * @param int $id_ebay_profile
+     * @return array|false|mysqli_result|null|PDOStatement|resource
+     * @throws PrestaShopDatabaseException
+     */
     public static function getEbayCategories($id_ebay_profile)
     {
         $ebay_profile = new EbayProfile($id_ebay_profile);
@@ -123,30 +132,33 @@ class EbayCategoryConfiguration
 			ON ec1.`id_category_ref_parent` = ec2.`id_category_ref`
 			AND ec1.`id_category_ref_parent` <> \'1\'
 			AND ec1.level <> 1
-			AND ec2.`id_country` = '.(int) $ebay_site_id.'
+			AND ec2.`id_country` = '.(int)$ebay_site_id.'
 			LEFT JOIN `'._DB_PREFIX_.'ebay_category` ec3
 			ON ec2.`id_category_ref_parent` = ec3.`id_category_ref`
 			AND ec2.`id_category_ref_parent` <> \'1\'
 			AND ec2.level <> 1
-			AND ec3.`id_country` = '.(int) $ebay_site_id.'
-			WHERE e.`id_ebay_profile` = '.(int) $id_ebay_profile.'
+			AND ec3.`id_country` = '.(int)$ebay_site_id.'
+			WHERE e.`id_ebay_profile` = '.(int)$id_ebay_profile.'
 			AND ec1.`id_category_ref` is not null';
 
         return Db::getInstance()->executeS($sql);
     }
 
-    /*
-     *
+    /**
      * get categories for which some multi variation product on PS were added to a non multi sku categorie on ebay
      *
-     **/
+     * @param EbayProfile $ebay_profile
+     * @param Context     $context
+     * @return array
+     * @throws PrestaShopDatabaseException
+     */
     public static function getMultiVarToNonMultiSku($ebay_profile, $context)
     {
         $cat_with_problem = array();
 
         $sql_get_cat_non_multi_sku = 'SELECT * FROM '._DB_PREFIX_.'ebay_category_configuration AS ecc
 			INNER JOIN '._DB_PREFIX_.'ebay_category AS ec ON ecc.id_ebay_category = ec.id_ebay_category
-			WHERE ecc.id_ebay_profile = '.(int) $ebay_profile->id.' GROUP BY name';
+			WHERE ecc.id_ebay_profile = '.(int)$ebay_profile->id.' GROUP BY name';
 
         foreach (Db::getInstance()->ExecuteS($sql_get_cat_non_multi_sku) as $cat) {
             if ($cat['is_multi_sku'] != 1 && EbayCategory::getInheritedIsMultiSku($cat['id_category_ref'], $ebay_profile->ebay_site_id) != 1) {
@@ -168,7 +180,6 @@ class EbayCategoryConfiguration
         }
 
         return $cat_with_problem;
-
     }
 
     public static function add($data)
@@ -178,62 +189,62 @@ class EbayCategoryConfiguration
 
     public static function updateByIdProfile($id_profile, $data)
     {
-        Db::getInstance()->autoExecute(_DB_PREFIX_.'ebay_category_configuration', $data, 'UPDATE', '`id_ebay_profile` = '.(int) $id_profile);
+        Db::getInstance()->autoExecute(_DB_PREFIX_.'ebay_category_configuration', $data, 'UPDATE', '`id_ebay_profile` = '.(int)$id_profile);
     }
 
     public static function updateByIdProfileAndIdCategory($id_profile, $id_category, $data)
     {
-        Db::getInstance()->autoExecute(_DB_PREFIX_.'ebay_category_configuration', $data, 'UPDATE', '`id_ebay_profile` = '.(int) $id_profile.' AND `id_category` = '.(int) $id_category);
+        Db::getInstance()->autoExecute(_DB_PREFIX_.'ebay_category_configuration', $data, 'UPDATE', '`id_ebay_profile` = '.(int)$id_profile.' AND `id_category` = '.(int)$id_category);
     }
 
     public static function deleteByIdCategory($id_ebay_profile, $id_category)
     {
         Db::getInstance()->execute('DELETE FROM `'._DB_PREFIX_.'ebay_category_configuration`
-			WHERE `id_ebay_profile` = '.(int) $id_ebay_profile.' AND `id_category` = '.(int) $id_category);
+			WHERE `id_ebay_profile` = '.(int)$id_ebay_profile.' AND `id_category` = '.(int)$id_category);
     }
 
     public static function getEbayCategoryConfigurations($id_ebay_profile)
     {
         return Db::getInstance()->executeS('SELECT *
 			FROM `'._DB_PREFIX_.'ebay_category_configuration`
-			WHERE `id_ebay_profile` = '.(int) $id_ebay_profile);
+			WHERE `id_ebay_profile` = '.(int)$id_ebay_profile);
     }
 
     public static function getTotalCategoryConfigurations($id_ebay_profile)
     {
         return Db::getInstance()->getValue('SELECT COUNT(`id_ebay_category_configuration`)
 			FROM `'._DB_PREFIX_.'ebay_category_configuration`
-			WHERE `id_ebay_profile` = '.(int) $id_ebay_profile);
+			WHERE `id_ebay_profile` = '.(int)$id_ebay_profile);
     }
 
     public static function getIdByCategoryId($id_ebay_profile, $id_category)
     {
         return Db::getInstance()->getValue('SELECT `id_ebay_category_configuration`
 			FROM `'._DB_PREFIX_.'ebay_category_configuration`
-			WHERE `id_ebay_profile` = '.(int) $id_ebay_profile.'
-			AND `id_category` = '.(int) $id_category);
+			WHERE `id_ebay_profile` = '.(int)$id_ebay_profile.'
+			AND `id_category` = '.(int)$id_category);
     }
 
     public static function getNbPrestashopCategories($id_ebay_profile)
     {
         return Db::getInstance()->getValue('SELECT count(*)
 			FROM `'._DB_PREFIX_.'ebay_category_configuration`
-			WHERE `id_ebay_profile` = '.(int) $id_ebay_profile);
+			WHERE `id_ebay_profile` = '.(int)$id_ebay_profile);
     }
 
     public static function getNbEbayCategories($id_ebay_profile)
     {
         return Db::getInstance()->getValue('SELECT count( DISTINCT(`id_ebay_category`))
 			FROM `'._DB_PREFIX_.'ebay_category_configuration`
-			WHERE `id_ebay_profile` = '.(int) $id_ebay_profile);
+			WHERE `id_ebay_profile` = '.(int)$id_ebay_profile);
     }
 
     public static function getImpactPrices($id_ebay_profile)
     {
         return array(
-            'positive_impact' => Db::getInstance()->getValue('SELECT COUNT(*) FROM '._DB_PREFIX_.'ebay_category_configuration WHERE percent NOT LIKE "-%" AND percent IS NOT NULL AND percent != "" AND id_ebay_profile = '.(int) $id_ebay_profile),
-            'negative_impact' => Db::getInstance()->getValue('SELECT COUNT(*) FROM '._DB_PREFIX_.'ebay_category_configuration WHERE percent LIKE "-%" AND id_ebay_profile = '.(int) $id_ebay_profile),
-            'impacts' => Db::getInstance()->ExecuteS('SELECT percent FROM '._DB_PREFIX_.'ebay_category_configuration WHERE percent IS NOT NULL AND percent != "" AND id_ebay_profile = '.(int) $id_ebay_profile),
+            'positive_impact' => Db::getInstance()->getValue('SELECT COUNT(*) FROM '._DB_PREFIX_.'ebay_category_configuration WHERE percent NOT LIKE "-%" AND percent IS NOT NULL AND percent != "" AND id_ebay_profile = '.(int)$id_ebay_profile),
+            'negative_impact' => Db::getInstance()->getValue('SELECT COUNT(*) FROM '._DB_PREFIX_.'ebay_category_configuration WHERE percent LIKE "-%" AND id_ebay_profile = '.(int)$id_ebay_profile),
+            'impacts'         => Db::getInstance()->ExecuteS('SELECT percent FROM '._DB_PREFIX_.'ebay_category_configuration WHERE percent IS NOT NULL AND percent != "" AND id_ebay_profile = '.(int)$id_ebay_profile),
         );
     }
 }

--- a/classes/EbayCategorySpecific.php
+++ b/classes/EbayCategorySpecific.php
@@ -18,10 +18,10 @@
  * versions in the future. If you wish to customize PrestaShop for your
  * needs please refer to http://www.prestashop.com for more information.
  *
- *  @author    PrestaShop SA <contact@prestashop.com>
- *  @copyright 2007-2016 PrestaShop SA
- *  @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
- *  International Registered Trademark & Property of PrestaShop SA
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2016 PrestaShop SA
+ * @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
  */
 
 require_once dirname(__FILE__).'/EbayRequest.php';
@@ -33,16 +33,19 @@ class EbayCategorySpecific
     const SELECTION_MODE_SELECTION_ONLY = 1;
 
     private static $prefix_to_field_names = array(
-        'attr' => 'id_attribute_group',
-        'feat' => 'id_feature',
-        'spec' => 'id_ebay_category_specific_value',
-        'brand' => 'is_brand',
+        'attr'      => 'id_attribute_group',
+        'feat'      => 'id_feature',
+        'spec'      => 'id_ebay_category_specific_value',
+        'brand'     => 'is_brand', // item specifics brand
+        'reference' => 'is_reference',
+        'ean'       => 'is_ean',
+        'upc'       => 'is_upc',
     );
 
     /**
      * Returns an array containing the correspondance between the form select fields prefix and the table field name
-     *
-     **/
+     * @return array
+     */
     public static function getPrefixToFieldNames()
     {
         return EbayCategorySpecific::$prefix_to_field_names;
@@ -51,7 +54,10 @@ class EbayCategorySpecific
     /**
      * Parse the data returned by the API and enter them in the table
      *
-     **/
+     * @param int  $id_ebay_profile
+     * @param bool $id_category
+     * @return bool
+     */
     public static function loadCategorySpecifics($id_ebay_profile, $id_category = false)
     {
         $request = new EbayRequest($id_ebay_profile);
@@ -69,16 +75,16 @@ class EbayCategorySpecific
             if ($xml_data->Recommendations->NameRecommendation) {
                 foreach ($xml_data->Recommendations->NameRecommendation as $recommendation) {
 
-                    $required = isset($recommendation->ValidationRules->MinValues) && ((int) $recommendation->ValidationRules->MinValues >= 1);
+                    $required = isset($recommendation->ValidationRules->MinValues) && ((int)$recommendation->ValidationRules->MinValues >= 1);
 
                     // if true can be used either in Item Specifics or VariationSpecifics
                     $can_variation = !(isset($recommendation->ValidationRules->VariationSpecifics)
-                        && ((string) $recommendation->ValidationRules->VariationSpecifics == 'Disabled'));
+                        && ((string)$recommendation->ValidationRules->VariationSpecifics == 'Disabled'));
 
                     if (isset($recommendation->ValidationRules->SelectionMode)) {
-                        if ((string) $recommendation->ValidationRules->SelectionMode == 'Prefilled') {
+                        if ((string)$recommendation->ValidationRules->SelectionMode == 'Prefilled') {
                             continue;
-                        } elseif ((string) $recommendation->ValidationRules->SelectionMode == 'SelectionOnly') {
+                        } elseif ((string)$recommendation->ValidationRules->SelectionMode == 'SelectionOnly') {
                             $selection_mode = EbayCategorySpecific::SELECTION_MODE_SELECTION_ONLY;
                         } else {
                             $selection_mode = EbayCategorySpecific::SELECTION_MODE_FREE_TEXT;
@@ -92,13 +98,13 @@ class EbayCategorySpecific
 
                     if (isset($recommendation->ValueRecommendation->Value)) {
                         foreach ($recommendation->ValueRecommendation as $value_recommendation) {
-                            $values[] = (string) $value_recommendation->Value;
+                            $values[] = (string)$value_recommendation->Value;
                         }
                     }
 
                     $db = Db::getInstance();
                     $db->execute('INSERT INTO `'._DB_PREFIX_.'ebay_category_specific` (`id_category_ref`, `name`, `required`, `can_variation`, `selection_mode`, `ebay_site_id`)
-						VALUES ('.(int) $ebay_category_id.', \''.pSQL((string) $recommendation->Name).'\', '.($required ? 1 : 0).', '.($can_variation ? 1 : 0).', '.($selection_mode ? 1 : 0).', '.(int) $ebay_profile->ebay_site_id.')
+						VALUES ('.(int)$ebay_category_id.', \''.pSQL((string)$recommendation->Name).'\', '.($required ? 1 : 0).', '.($can_variation ? 1 : 0).', '.($selection_mode ? 1 : 0).', '.(int)$ebay_profile->ebay_site_id.')
 						ON DUPLICATE KEY UPDATE `required` = '.($required ? 1 : 0).', `can_variation` = '.($can_variation ? 1 : 0).', `selection_mode` = '.($selection_mode ? 1 : 0));
 
                     $ebay_category_specific_id = $db->Insert_ID();
@@ -106,17 +112,17 @@ class EbayCategorySpecific
                     if (!$ebay_category_specific_id) {
                         $ebay_category_specific_id = $db->getValue('SELECT `id_ebay_category_specific`
 							FROM `'._DB_PREFIX_.'ebay_category_specific`
-							WHERE `id_category_ref` = '.(int) $ebay_category_id.'
-							AND `ebay_site_id` = '.(int) $ebay_profile->ebay_site_id.'
-							AND `name` = \''.pSQL((string) $recommendation->Name).'\'');
+							WHERE `id_category_ref` = '.(int)$ebay_category_id.'
+							AND `ebay_site_id` = '.(int)$ebay_profile->ebay_site_id.'
+							AND `name` = \''.pSQL((string)$recommendation->Name).'\'');
                     }
 
                     $insert_data = array();
 
                     foreach ($values as $value) {
                         $insert_data[] = array(
-                            'id_ebay_category_specific' => (int) $ebay_category_specific_id,
-                            'value' => pSQL($value),
+                            'id_ebay_category_specific' => (int)$ebay_category_specific_id,
+                            'value'                     => pSQL($value),
                         );
                     }
 
@@ -138,6 +144,7 @@ class EbayCategorySpecific
             }
 
         }
+
         return false;
     }
 
@@ -150,12 +157,13 @@ class EbayCategorySpecific
             }
 
         }
+
         return true;
     }
 
     public static function isConfigured($item_specific)
     {
-        if ($item_specific['id_attribute_group'] != 0 || $item_specific['id_feature'] != 0 || $item_specific['id_ebay_category_specific_value'] != 0 || $item_specific['is_brand'] != 0) {
+        if ($item_specific['id_attribute_group'] != 0 || $item_specific['id_feature'] != 0 || $item_specific['id_ebay_category_specific_value'] != 0 || $item_specific['is_brand'] != 0 || $item_specific['is_reference'] != 0 || $item_specific['is_ean'] != 0 || $item_specific['is_upc'] != 0) {
             return true;
         }
 
@@ -165,30 +173,32 @@ class EbayCategorySpecific
     public static function getAllMandatory($id_ebay_profile)
     {
         $ebay_profile = new EbayProfile($id_ebay_profile);
+
         return Db::getInstance()->ExecuteS('
 			SELECT * FROM '._DB_PREFIX_.'ebay_category_specific ecs
 			INNER JOIN '._DB_PREFIX_.'ebay_category ec
 			ON ecs.id_category_ref = ec.id_category_ref
 			AND ecs.`ebay_site_id` = ec.`id_country`
-			AND ec.`id_country` = '.(int) $ebay_profile->ebay_site_id.'
+			AND ec.`id_country` = '.(int)$ebay_profile->ebay_site_id.'
 			INNER JOIN `'._DB_PREFIX_.'ebay_category_configuration` ecc
 			ON ec.`id_ebay_category` = ecc.`id_ebay_category`
-			AND ecc.`id_ebay_profile` = '.(int) $id_ebay_profile.'
+			AND ecc.`id_ebay_profile` = '.(int)$id_ebay_profile.'
 			WHERE required = 1');
     }
 
     public static function getAllOptional($id_ebay_profile)
     {
         $ebay_profile = new EbayProfile($id_ebay_profile);
+
         return Db::getInstance()->ExecuteS('
 			SELECT * FROM '._DB_PREFIX_.'ebay_category_specific ecs
 			INNER JOIN '._DB_PREFIX_.'ebay_category ec
 			ON ecs.id_category_ref = ec.id_category_ref
 			AND ecs.`ebay_site_id` = ec.`id_country`
-			AND ec.`id_country` = '.(int) $ebay_profile->ebay_site_id.'
+			AND ec.`id_country` = '.(int)$ebay_profile->ebay_site_id.'
 			INNER JOIN `'._DB_PREFIX_.'ebay_category_configuration` ecc
 			ON ec.`id_ebay_category` = ecc.`id_ebay_category`
-			AND ecc.`id_ebay_profile` = '.(int) $id_ebay_profile.'
+			AND ecc.`id_ebay_profile` = '.(int)$id_ebay_profile.'
 			WHERE required = 0');
     }
 
@@ -200,12 +210,13 @@ class EbayCategorySpecific
 			INNER JOIN `'._DB_PREFIX_.'ebay_category` ec
 			ON ecs.`id_category_ref` = ec.`id_category_ref`
 			AND ecs.`ebay_site_id` = ec.`id_country`
-			AND ec.`id_country` = '.(int) $ebay_profile->ebay_site_id.'
+			AND ec.`id_country` = '.(int)$ebay_profile->ebay_site_id.'
 			INNER JOIN `'._DB_PREFIX_.'ebay_category_configuration` ecc
 			ON ec.`id_ebay_category` = ecc.`id_ebay_category`
-			AND ecc.`id_ebay_profile` = '.(int) $id_ebay_profile.'
+			AND ecc.`id_ebay_profile` = '.(int)$id_ebay_profile.'
 			WHERE ecs.`required` = 0
 			AND `id_ebay_category_specific_value` > 0';
+
         return Db::getInstance()->getValue($sql);
     }
 }

--- a/classes/EbayDeliveryTimeOptions.php
+++ b/classes/EbayDeliveryTimeOptions.php
@@ -18,10 +18,10 @@
  * versions in the future. If you wish to customize PrestaShop for your
  * needs please refer to http://www.prestashop.com for more information.
  *
- *  @author    PrestaShop SA <contact@prestashop.com>
- *  @copyright 2007-2016 PrestaShop SA
- *  @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
- *  International Registered Trademark & Property of PrestaShop SA
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2016 PrestaShop SA
+ * @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
  */
 
 class EbayDeliveryTimeOptions

--- a/classes/EbayProductConfiguration.php
+++ b/classes/EbayProductConfiguration.php
@@ -18,15 +18,14 @@
  * versions in the future. If you wish to customize PrestaShop for your
  * needs please refer to http://www.prestashop.com for more information.
  *
- *  @author    PrestaShop SA <contact@prestashop.com>
- *  @copyright 2007-2016 PrestaShop SA
- *  @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
- *  International Registered Trademark & Property of PrestaShop SA
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2016 PrestaShop SA
+ * @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
  */
 
 class EbayProductConfiguration
 {
-
     public static function getByProductIdAndProfile($product_id, $id_ebay_profile)
     {
         if (!$product_id) {
@@ -35,15 +34,15 @@ class EbayProductConfiguration
 
         return Db::getInstance()->getRow('SELECT `id_product`, `blacklisted`, `extra_images`
 			FROM `'._DB_PREFIX_.'ebay_product_configuration`
-			WHERE `id_product` = '.(int) $product_id.'
-			AND `id_ebay_profile` = '.(int) $id_ebay_profile);
+			WHERE `id_product` = '.(int)$product_id.'
+			AND `id_ebay_profile` = '.(int)$id_ebay_profile);
     }
 
     public static function getBlacklistedProductIdsQuery($id_ebay_profile)
     {
         return 'SELECT `id_product`
 			FROM `'._DB_PREFIX_.'ebay_product_configuration`
-			WHERE `id_ebay_profile` = '.(int) $id_ebay_profile.'
+			WHERE `id_ebay_profile` = '.(int)$id_ebay_profile.'
 			AND `blacklisted` = 1';
     }
 
@@ -61,7 +60,7 @@ class EbayProductConfiguration
         }
 
         $sql = 'INSERT INTO `'._DB_PREFIX_.'ebay_product_configuration` (`id_product`, `'.implode('`,`', array_keys($to_insert)).'`)
-			VALUES ('.(int) $product_id.', '.implode(',', $to_insert).')
+			VALUES ('.(int)$product_id.', '.implode(',', $to_insert).')
 			ON DUPLICATE KEY UPDATE ';
 
         $sql .= implode(',', $fields_strs);

--- a/classes/EbayRequest.php
+++ b/classes/EbayRequest.php
@@ -18,10 +18,10 @@
  * versions in the future. If you wish to customize PrestaShop for your
  * needs please refer to http://www.prestashop.com for more information.
  *
- *  @author    PrestaShop SA <contact@prestashop.com>
- *  @copyright 2007-2016 PrestaShop SA
- *  @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
- *  International Registered Trademark & Property of PrestaShop SA
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2016 PrestaShop SA
+ * @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
  */
 
 if (file_exists(dirname(__FILE__).'/EbayCountrySpec.php')) {
@@ -62,7 +62,7 @@ class EbayRequest
         require dirname(__FILE__).'/../backward_compatibility/backward.php';
 
         $this->itemConditionError = false;
-        $this->debug = (boolean) Configuration::get('EBAY_ACTIVATE_LOGS');
+        $this->debug = (boolean)Configuration::get('EBAY_ACTIVATE_LOGS');
 
         if ($id_ebay_profile) {
             $this->ebay_profile = new EbayProfile($id_ebay_profile);
@@ -122,13 +122,13 @@ class EbayRequest
             return false;
         }
 
-        return ($this->session = (string) $response->SessionID);
+        return ($this->session = (string)$response->SessionID);
     }
 
     public function fetchToken($username, $session)
     {
         $response = $this->_makeRequest('FetchToken', array(
-            'username' => $username,
+            'username'   => $username,
             'session_id' => $session,
         ));
 
@@ -136,7 +136,7 @@ class EbayRequest
             return false;
         }
 
-        return (string) $response->eBayAuthToken;
+        return (string)$response->eBayAuthToken;
     }
 
     /**
@@ -155,8 +155,8 @@ class EbayRequest
         }
 
         $userProfile = array(
-            'StoreUrl' => $response->User->StoreURL,
-            'StoreName' => $response->User->StoreName,
+            'StoreUrl'           => $response->User->StoreURL,
+            'StoreName'          => $response->User->StoreName,
             'SellerBusinessType' => $response->User->SellerBusinessType,
         );
 
@@ -173,11 +173,11 @@ class EbayRequest
     public function getCategories($all = true)
     {
         $response = $this->_makeRequest('GetCategories', array(
-            'version' => $this->compatibility_level,
+            'version'          => $this->compatibility_level,
             'category_site_id' => $this->ebay_country->getSiteID(),
-            'all' => $all === true ? true : false,
-            'root' => $all === false ? true : false,
-            'id_category' => is_numeric($all) ? $all : null,
+            'all'              => $all === true ? true : false,
+            'root'             => $all === false ? true : false,
+            'id_category'      => is_numeric($all) ? $all : null,
         ));
 
         if ($response === false) {
@@ -190,7 +190,7 @@ class EbayRequest
             $category = array();
 
             foreach ($cat as $key => $value) {
-                $category[(string) $key] = (string) $value;
+                $category[(string)$key] = (string)$value;
             }
 
             $categories[] = $category;
@@ -208,7 +208,7 @@ class EbayRequest
     {
         $response = $this->_makeRequest('GetCategoryFeatures', array(
             'feature_id' => 'VariationsEnabled',
-            'version' => $this->compatibility_level,
+            'version'    => $this->compatibility_level,
         ));
 
         if ($response === false) {
@@ -218,7 +218,7 @@ class EbayRequest
         $compliancies = array();
 
         foreach ($response->Category as $cat) {
-            $compliancies[(string) $cat->CategoryID] = ((string) $cat->VariationsEnabled === 'true' ? 1 : 0);
+            $compliancies[(string)$cat->CategoryID] = ((string)$cat->VariationsEnabled === 'true' ? 1 : 0);
         }
 
         return $compliancies;
@@ -227,7 +227,7 @@ class EbayRequest
     public function getCategoryFeatures($category_id)
     {
         $response = $this->_makeRequest('GetCategoryFeatures', array(
-            'version' => $this->compatibility_level,
+            'version'     => $this->compatibility_level,
             'category_id' => $category_id,
         ));
 
@@ -241,7 +241,7 @@ class EbayRequest
     public function getCategorySpecifics($category_id)
     {
         $response = $this->_makeRequest('GetCategorySpecifics', array(
-            'version' => $this->compatibility_level,
+            'version'     => $this->compatibility_level,
             'category_id' => $category_id,
         ));
 
@@ -256,7 +256,7 @@ class EbayRequest
     {
         $response = $this->_makeRequest('GetSuggestedCategories', array(
             'version' => $this->compatibility_level,
-            'query' => Tools::substr(Tools::strtolower($query), 0, 350),
+            'query'   => Tools::substr(Tools::strtolower($query), 0, 350),
         ));
 
         if ($response === false) {
@@ -264,7 +264,7 @@ class EbayRequest
         }
 
         if (isset($response->SuggestedCategoryArray->SuggestedCategory[0]->Category->CategoryID)) {
-            return (int) $response->SuggestedCategoryArray->SuggestedCategory[0]->Category->CategoryID;
+            return (int)$response->SuggestedCategoryArray->SuggestedCategory[0]->Category->CategoryID;
         }
 
         return 0;
@@ -289,11 +289,15 @@ class EbayRequest
         foreach ($response->ReturnPolicyDetails as $return_policy_details) {
             foreach ($return_policy_details as $key => $returns) {
                 if ($key == 'ReturnsAccepted') {
-                    $returns_policies[] = array('value' => (string) $returns->ReturnsAcceptedOption, 'description' => (string) $returns->Description);
-                } else if ($key == 'ReturnsWithin') {
-                    $returns_within[] = array('value' => (string) $returns->ReturnsWithinOption, 'description' => (string) $returns->Description);
-                } else if ($key == 'ShippingCostPaidBy') {
-                    $returns_whopays[] = array('value' => (string) $returns->ShippingCostPaidByOption, 'description' => (string) $returns->Description);
+                    $returns_policies[] = array('value' => (string)$returns->ReturnsAcceptedOption, 'description' => (string)$returns->Description);
+                } else {
+                    if ($key == 'ReturnsWithin') {
+                        $returns_within[] = array('value' => (string)$returns->ReturnsWithinOption, 'description' => (string)$returns->Description);
+                    } else {
+                        if ($key == 'ShippingCostPaidBy') {
+                            $returns_whopays[] = array('value' => (string)$returns->ShippingCostPaidByOption, 'description' => (string)$returns->Description);
+                        }
+                    }
                 }
 
             }
@@ -301,8 +305,8 @@ class EbayRequest
 
         return array(
             'ReturnsAccepted' => $returns_policies,
-            'ReturnsWithin' => $returns_within,
-            'ReturnsWhoPays' => $returns_whopays,
+            'ReturnsWithin'   => $returns_within,
+            'ReturnsWhoPays'  => $returns_whopays,
         );
     }
 
@@ -321,7 +325,7 @@ class EbayRequest
         foreach ($response->ShippingLocationDetails as $line) {
             $shipping_locations[] = array(
                 'description' => strip_tags($line->Description->asXML()),
-                'location' => strip_tags($line->ShippingLocation->asXML()),
+                'location'    => strip_tags($line->ShippingLocation->asXML()),
             );
         }
 
@@ -343,9 +347,9 @@ class EbayRequest
 
         foreach ($response->ExcludeShippingLocationDetails as $line) {
             $shipping_locations[] = array(
-                'region' => strip_tags($line->Region->asXML()),
+                'region'      => strip_tags($line->Region->asXML()),
                 'description' => strip_tags($line->Description->asXML()),
-                'location' => strip_tags($line->Location->asXML()),
+                'location'    => strip_tags($line->Location->asXML()),
             );
         }
 
@@ -367,12 +371,12 @@ class EbayRequest
 
         foreach ($response->ShippingServiceDetails as $carrier) {
             $carriers[] = array(
-                'description' => strip_tags($carrier->Description->asXML()),
-                'shippingService' => strip_tags($carrier->ShippingService->asXML()),
-                'shippingServiceID' => strip_tags($carrier->ShippingServiceID->asXML()),
-                'ServiceType' => strip_tags($carrier->ServiceType->asXML()),
+                'description'          => strip_tags($carrier->Description->asXML()),
+                'shippingService'      => strip_tags($carrier->ShippingService->asXML()),
+                'shippingServiceID'    => strip_tags($carrier->ShippingServiceID->asXML()),
+                'ServiceType'          => strip_tags($carrier->ServiceType->asXML()),
                 'InternationalService' => (isset($carrier->InternationalService) ? strip_tags($carrier->InternationalService->asXML()) : false),
-                'ebay_site_id' => (int) $this->ebay_profile->ebay_site_id,
+                'ebay_site_id'         => (int)$this->ebay_profile->ebay_site_id,
             );
         }
 
@@ -393,7 +397,7 @@ class EbayRequest
         foreach ($response->DispatchTimeMaxDetails as $DeliveryTimeOption) {
             $delivery_time_options[] = array(
                 'DispatchTimeMax' => strip_tags($DeliveryTimeOption->DispatchTimeMax->asXML()),
-                'description' => strip_tags($DeliveryTimeOption->Description->asXML()),
+                'description'     => strip_tags($DeliveryTimeOption->Description->asXML()),
             );
         }
 
@@ -416,28 +420,28 @@ class EbayRequest
         $currency = new Currency($this->ebay_profile->getConfiguration('EBAY_CURRENCY'));
 
         $vars = array(
-            'sku' => 'prestashop-'.$data['id_product'],
-            'title' => Tools::substr(self::prepareTitle($data), 0, 80),
-            'pictures' => isset($data['pictures']) ? $data['pictures'] : array(),
-            'description' => $data['description'],
-            'category_id' => $data['categoryId'],
-            'condition_id' => $data['condition'],
-            'price_update' => !isset($data['noPriceUpdate']),
-            'start_price' => $data['price'],
-            'country' => Tools::strtoupper($this->ebay_profile->getConfiguration('EBAY_SHOP_COUNTRY')),
-            'country_currency' => $currency->iso_code,
-            'dispatch_time_max' => $this->ebay_profile->getConfiguration('EBAY_DELIVERY_TIME'),
-            'listing_duration' => $this->ebay_profile->getConfiguration('EBAY_LISTING_DURATION'),
-            'pay_pal_email_address' => $this->ebay_profile->getConfiguration('EBAY_PAYPAL_EMAIL'),
-            'postal_code' => $this->ebay_profile->getConfiguration('EBAY_SHOP_POSTALCODE'),
-            'quantity' => $data['quantity'],
-            'item_specifics' => $data['item_specifics'],
-            'return_policy' => $this->_getReturnPolicy(),
-            'shipping_details' => $this->_getShippingDetails($data),
+            'sku'                        => 'prestashop-'.$data['id_product'],
+            'title'                      => Tools::substr(self::prepareTitle($data), 0, 80),
+            'pictures'                   => isset($data['pictures']) ? $data['pictures'] : array(),
+            'description'                => $data['description'],
+            'category_id'                => $data['categoryId'],
+            'condition_id'               => $data['condition'],
+            'price_update'               => !isset($data['noPriceUpdate']),
+            'start_price'                => $data['price'],
+            'country'                    => Tools::strtoupper($this->ebay_profile->getConfiguration('EBAY_SHOP_COUNTRY')),
+            'country_currency'           => $currency->iso_code,
+            'dispatch_time_max'          => $this->ebay_profile->getConfiguration('EBAY_DELIVERY_TIME'),
+            'listing_duration'           => $this->ebay_profile->getConfiguration('EBAY_LISTING_DURATION'),
+            'pay_pal_email_address'      => $this->ebay_profile->getConfiguration('EBAY_PAYPAL_EMAIL'),
+            'postal_code'                => $this->ebay_profile->getConfiguration('EBAY_SHOP_POSTALCODE'),
+            'quantity'                   => $data['quantity'],
+            'item_specifics'             => $data['item_specifics'],
+            'return_policy'              => $this->_getReturnPolicy(),
+            'shipping_details'           => $this->_getShippingDetails($data),
             'buyer_requirements_details' => $this->_getBuyerRequirementDetails($data),
-            'site' => $this->ebay_country->getSiteName(),
-            'autopay' => $this->ebay_profile->getConfiguration('EBAY_IMMEDIATE_PAYMENT'),
-            'product_listing_details' => $this->_getProductListingDetails($data),
+            'site'                       => $this->ebay_country->getSiteName(),
+            'autopay'                    => $this->ebay_profile->getConfiguration('EBAY_IMMEDIATE_PAYMENT'),
+            'product_listing_details'    => $this->_getProductListingDetails($data),
 
         );
 
@@ -468,25 +472,25 @@ class EbayRequest
         }
 
         $vars = array(
-            'item_id' => $data['itemID'],
-            'condition_id' => $data['condition'],
-            'pictures' => isset($data['pictures']) ? $data['pictures'] : array(),
-            'sku' => 'prestashop-'.$data['id_product'],
-            'dispatch_time_max' => $this->ebay_profile->getConfiguration('EBAY_DELIVERY_TIME'),
-            'listing_duration' => $this->ebay_profile->getConfiguration('EBAY_LISTING_DURATION'),
-            'quantity' => $data['quantity'],
-            'price_update' => !isset($data['noPriceUpdate']),
-            'start_price' => $data['price'],
-            'resynchronize' => ($this->ebay_profile->getConfiguration('EBAY_SYNC_OPTION_RESYNC') != 1),
-            'title' => Tools::substr(self::prepareTitle($data), 0, 80),
-            'description' => $data['description'],
-            'shipping_details' => $this->_getShippingDetails($data),
+            'item_id'                    => $data['itemID'],
+            'condition_id'               => $data['condition'],
+            'pictures'                   => isset($data['pictures']) ? $data['pictures'] : array(),
+            'sku'                        => 'prestashop-'.$data['id_product'],
+            'dispatch_time_max'          => $this->ebay_profile->getConfiguration('EBAY_DELIVERY_TIME'),
+            'listing_duration'           => $this->ebay_profile->getConfiguration('EBAY_LISTING_DURATION'),
+            'quantity'                   => $data['quantity'],
+            'price_update'               => !isset($data['noPriceUpdate']),
+            'start_price'                => $data['price'],
+            'resynchronize'              => ($this->ebay_profile->getConfiguration('EBAY_SYNC_OPTION_RESYNC') != 1),
+            'title'                      => Tools::substr(self::prepareTitle($data), 0, 80),
+            'description'                => $data['description'],
+            'shipping_details'           => $this->_getShippingDetails($data),
             'buyer_requirements_details' => $this->_getBuyerRequirementDetails($data),
-            'return_policy' => $this->_getReturnPolicy(),
-            'item_specifics' => $data['item_specifics'],
-            'country' => Tools::strtoupper($this->ebay_profile->getConfiguration('EBAY_SHOP_COUNTRY')),
-            'autopay' => $this->ebay_profile->getConfiguration('EBAY_IMMEDIATE_PAYMENT'),
-            'product_listing_details' => $this->_getProductListingDetails($data),
+            'return_policy'              => $this->_getReturnPolicy(),
+            'item_specifics'             => $data['item_specifics'],
+            'country'                    => Tools::strtoupper($this->ebay_profile->getConfiguration('EBAY_SHOP_COUNTRY')),
+            'autopay'                    => $this->ebay_profile->getConfiguration('EBAY_IMMEDIATE_PAYMENT'),
+            'product_listing_details'    => $this->_getProductListingDetails($data),
 
         );
 
@@ -543,26 +547,26 @@ class EbayRequest
 
         // Build the request Xml string
         $vars = array(
-            'country' => Tools::strtoupper($this->ebay_profile->getConfiguration('EBAY_SHOP_COUNTRY')),
-            'country_currency' => $currency->iso_code,
-            'description' => $data['description'],
-            'condition_id' => $data['condition'],
-            'dispatch_time_max' => $this->ebay_profile->getConfiguration('EBAY_DELIVERY_TIME'),
-            'listing_duration' => $this->ebay_profile->getConfiguration('EBAY_LISTING_DURATION'),
-            'pay_pal_email_address' => $this->ebay_profile->getConfiguration('EBAY_PAYPAL_EMAIL'),
-            'postal_code' => $this->ebay_profile->getConfiguration('EBAY_SHOP_POSTALCODE'),
-            'category_id' => $data['categoryId'],
-            'title' => Tools::substr(self::prepareTitle($data), 0, 80),
-            'pictures' => isset($data['pictures']) ? $data['pictures'] : array(),
-            'return_policy' => $this->_getReturnPolicy(),
-            'price_update' => !isset($data['noPriceUpdate']),
-            'variations' => $this->_getVariations($data),
-            'product_listing_details' => $this->_getProductListingDetails($data),
-            'shipping_details' => $this->_getShippingDetails($data),
+            'country'                    => Tools::strtoupper($this->ebay_profile->getConfiguration('EBAY_SHOP_COUNTRY')),
+            'country_currency'           => $currency->iso_code,
+            'description'                => $data['description'],
+            'condition_id'               => $data['condition'],
+            'dispatch_time_max'          => $this->ebay_profile->getConfiguration('EBAY_DELIVERY_TIME'),
+            'listing_duration'           => $this->ebay_profile->getConfiguration('EBAY_LISTING_DURATION'),
+            'pay_pal_email_address'      => $this->ebay_profile->getConfiguration('EBAY_PAYPAL_EMAIL'),
+            'postal_code'                => $this->ebay_profile->getConfiguration('EBAY_SHOP_POSTALCODE'),
+            'category_id'                => $data['categoryId'],
+            'title'                      => Tools::substr(self::prepareTitle($data), 0, 80),
+            'pictures'                   => isset($data['pictures']) ? $data['pictures'] : array(),
+            'return_policy'              => $this->_getReturnPolicy(),
+            'price_update'               => !isset($data['noPriceUpdate']),
+            'variations'                 => $this->_getVariations($data),
+            'product_listing_details'    => $this->_getProductListingDetails($data),
+            'shipping_details'           => $this->_getShippingDetails($data),
             'buyer_requirements_details' => $this->_getBuyerRequirementDetails($data),
-            'site' => $this->ebay_country->getSiteName(),
-            'item_specifics' => $data['item_specifics'],
-            'autopay' => $this->ebay_profile->getConfiguration('EBAY_IMMEDIATE_PAYMENT'),
+            'site'                       => $this->ebay_country->getSiteName(),
+            'item_specifics'             => $data['item_specifics'],
+            'autopay'                    => $this->ebay_profile->getConfiguration('EBAY_IMMEDIATE_PAYMENT'),
         );
 
         if (isset($data['ebay_store_category_id']) && $data['ebay_store_category_id']) {
@@ -589,7 +593,7 @@ class EbayRequest
         }
 
         $response = $this->_makeRequest('RelistFixedPriceItem', array(
-            'item_id' => (int) $item_id,
+            'item_id' => (int)$item_id,
         ));
 
         if ($response === false) {
@@ -612,29 +616,29 @@ class EbayRequest
         $currency = new Currency($this->ebay_profile->getConfiguration('EBAY_CURRENCY'));
 
         $vars = array(
-            'item_id' => $data['itemID'],
-            'country' => Tools::strtoupper($this->ebay_profile->getConfiguration('EBAY_SHOP_COUNTRY')),
-            'country_currency' => $currency->iso_code,
-            'condition_id' => $data['condition'],
-            'dispatch_time_max' => $this->ebay_profile->getConfiguration('EBAY_DELIVERY_TIME'),
-            'listing_duration' => $this->ebay_profile->getConfiguration('EBAY_LISTING_DURATION'),
-            'listing_type' => 'FixedPriceItem',
-            'payment_method' => 'PayPal',
-            'pay_pal_email_address' => $this->ebay_profile->getConfiguration('EBAY_PAYPAL_EMAIL'),
-            'postal_code' => $this->ebay_profile->getConfiguration('EBAY_SHOP_POSTALCODE'),
-            'category_id' => $data['categoryId'],
-            'pictures' => isset($data['pictures']) ? $data['pictures'] : array(),
-            'return_policy' => $this->_getReturnPolicy(),
-            'resynchronize' => ($this->ebay_profile->getConfiguration('EBAY_SYNC_OPTION_RESYNC') != 1),
-            'title' => Tools::substr(self::prepareTitle($data), 0, 80),
-            'description' => $data['description'],
-            'shipping_details' => $this->_getShippingDetails($data),
+            'item_id'                    => $data['itemID'],
+            'country'                    => Tools::strtoupper($this->ebay_profile->getConfiguration('EBAY_SHOP_COUNTRY')),
+            'country_currency'           => $currency->iso_code,
+            'condition_id'               => $data['condition'],
+            'dispatch_time_max'          => $this->ebay_profile->getConfiguration('EBAY_DELIVERY_TIME'),
+            'listing_duration'           => $this->ebay_profile->getConfiguration('EBAY_LISTING_DURATION'),
+            'listing_type'               => 'FixedPriceItem',
+            'payment_method'             => 'PayPal',
+            'pay_pal_email_address'      => $this->ebay_profile->getConfiguration('EBAY_PAYPAL_EMAIL'),
+            'postal_code'                => $this->ebay_profile->getConfiguration('EBAY_SHOP_POSTALCODE'),
+            'category_id'                => $data['categoryId'],
+            'pictures'                   => isset($data['pictures']) ? $data['pictures'] : array(),
+            'return_policy'              => $this->_getReturnPolicy(),
+            'resynchronize'              => ($this->ebay_profile->getConfiguration('EBAY_SYNC_OPTION_RESYNC') != 1),
+            'title'                      => Tools::substr(self::prepareTitle($data), 0, 80),
+            'description'                => $data['description'],
+            'shipping_details'           => $this->_getShippingDetails($data),
             'buyer_requirements_details' => $this->_getBuyerRequirementDetails($data),
-            'site' => $this->ebay_country->getSiteName(),
-            'variations' => $this->_getVariations($data),
-            'product_listing_details' => $this->_getProductListingDetails($data),
-            'item_specifics' => $data['item_specifics'],
-            'autopay' => $this->ebay_profile->getConfiguration('EBAY_IMMEDIATE_PAYMENT'),
+            'site'                       => $this->ebay_country->getSiteName(),
+            'variations'                 => $this->_getVariations($data),
+            'product_listing_details'    => $this->_getProductListingDetails($data),
+            'item_specifics'             => $data['item_specifics'],
+            'autopay'                    => $this->ebay_profile->getConfiguration('EBAY_IMMEDIATE_PAYMENT'),
         );
 
         if (isset($data['ebay_store_category_id']) && $data['ebay_store_category_id']) {
@@ -661,8 +665,8 @@ class EbayRequest
 
         $vars = array(
             'create_time_from' => $create_time_from,
-            'create_time_to' => $create_time_to,
-            'page_number' => $page,
+            'create_time_to'   => $create_time_to,
+            'page_number'      => $page,
         );
 
         $response = $this->_makeRequest('GetOrders', $vars);
@@ -674,7 +678,7 @@ class EbayRequest
         // Checking Errors
         $this->error = '';
 
-        if (isset($response->Errors) && isset($response->Ack) && (string) $response->Ack != 'Success' && (string) $response->Ack != 'Warning') {
+        if (isset($response->Errors) && isset($response->Ack) && (string)$response->Ack != 'Success' && (string)$response->Ack != 'Warning') {
             foreach ($response->Errors as $e) {
                 if ($this->error != '') {
                     $this->error .= '<br />';
@@ -684,7 +688,7 @@ class EbayRequest
                     Configuration::updateValue('EBAY_TOKEN_REGENERATE', true, false, 0, 0);
                 }
 
-                $this->error .= (string) $e->LongMessage;
+                $this->error .= (string)$e->LongMessage;
             }
         }
 
@@ -701,6 +705,7 @@ class EbayRequest
         // Set Api Call
         $this->apiCall = 'GetStore';
         $response = $this->_makeRequest('GetStore');
+
         return ($response === false) ? false : (isset($response->Store) ? $response->Store->CustomCategories->CustomCategory : false);
 
     }
@@ -744,9 +749,9 @@ class EbayRequest
         $this->apiCall = 'CompleteSale';
 
         $vars = array(
-            'id_order_ref' => $id_order_ref,
+            'id_order_ref'    => $id_order_ref,
             'tracking_number' => $tracking_number,
-            'carrier_name' => $carrier_name,
+            'carrier_name'    => $carrier_name,
         );
 
         $response = $this->_makeRequest('CompleteSale', $vars);
@@ -767,9 +772,9 @@ class EbayRequest
         }
 
         $vars = array(
-            'picture_url' => $picture_url,
+            'picture_url'  => $picture_url,
             'picture_name' => $picture_name,
-            'version' => $this->compatibility_level,
+            'version'      => $this->compatibility_level,
         );
 
         $response = $this->_makeRequest('UploadSiteHostedPictures', $vars);
@@ -779,7 +784,7 @@ class EbayRequest
         }
 
         if ($this->_checkForErrors($response)) {
-            return (string) $response->SiteHostedPictureDetails->FullURL;
+            return (string)$response->SiteHostedPictureDetails->FullURL;
         }
 
         return null;
@@ -788,10 +793,10 @@ class EbayRequest
     private function _getShippingDetails($data)
     {
         $vars = array(
-            'excluded_zones' => $data['shipping']['excludedZone'],
-            'national_services' => $data['shipping']['nationalShip'],
+            'excluded_zones'         => $data['shipping']['excludedZone'],
+            'national_services'      => $data['shipping']['nationalShip'],
             'international_services' => $data['shipping']['internationalShip'],
-            'currency_id' => $this->ebay_country->getCurrency(),
+            'currency_id'            => $this->ebay_country->getCurrency(),
         );
 
         $this->smarty->assign($vars);
@@ -801,7 +806,7 @@ class EbayRequest
 
     private function _getBuyerRequirementDetails($datas)
     {
-        $vars = array('has_excluded_zones' => (boolean) count($datas['shipping']['excludedZone']));
+        $vars = array('has_excluded_zones' => (boolean)count($datas['shipping']['excludedZone']));
         $this->smarty->assign($vars);
 
         return $this->smarty->fetch(dirname(__FILE__).'/../ebay/api/GetBuyerRequirementDetails.tpl');
@@ -812,9 +817,9 @@ class EbayRequest
         $returns_policy_configuration = $this->ebay_profile->getReturnsPolicyConfiguration();
         $vars = array(
             'returns_accepted_option' => $returns_policy_configuration->ebay_returns_accepted_option,
-            'description' => preg_replace('#<br\s*?/?>#i', "\n", $returns_policy_configuration->ebay_returns_description),
-            'within' => $returns_policy_configuration->ebay_returns_within,
-            'whopays' => $returns_policy_configuration->ebay_returns_who_pays,
+            'description'             => preg_replace('#<br\s*?/?>#i', "\n", $returns_policy_configuration->ebay_returns_description),
+            'within'                  => $returns_policy_configuration->ebay_returns_within,
+            'whopays'                 => $returns_policy_configuration->ebay_returns_who_pays,
         );
 
         $this->smarty->assign($vars);
@@ -825,14 +830,30 @@ class EbayRequest
     private function _getProductListingDetails($data)
     {
         $vars = array(
-            'ean'               => $this->configurationValues($data, Configuration::get('EBAY_SYNCHRONIZE_EAN')),
-            'mpn'               => $this->configurationValues($data, Configuration::get('EBAY_SYNCHRONIZE_MPN')),
-            'upc'               => $this->configurationValues($data, Configuration::get('EBAY_SYNCHRONIZE_UPC')),
-            'isbn'              => $this->configurationValues($data, Configuration::get('EBAY_SYNCHRONIZE_ISBN')),
-            'manufacturer_name' => $data['manufacturer_name'],
+            'ean'                => $this->configurationValues($data, Configuration::get('EBAY_SYNCHRONIZE_EAN')),
+            'mpn'                => $this->configurationValues($data, Configuration::get('EBAY_SYNCHRONIZE_MPN')),
+            'upc'                => $this->configurationValues($data, Configuration::get('EBAY_SYNCHRONIZE_UPC')),
+            'isbn'               => $this->configurationValues($data, Configuration::get('EBAY_SYNCHRONIZE_ISBN')),
+            'manufacturer_name'  => $data['manufacturer_name'],
             'ean_not_applicable' => (int)Configuration::get('EBAY_EAN_NOT_APPLICABLE'),
-
+            'synchronize_ean'    => (string)Configuration::get('EBAY_SYNCHRONIZE_EAN'),
+            'synchronize_mpn'    => (string)Configuration::get('EBAY_SYNCHRONIZE_MPN'),
+            'synchronize_upc'    => (string)Configuration::get('EBAY_SYNCHRONIZE_UPC'),
+            'synchronize_isbn'   => (string)Configuration::get('EBAY_SYNCHRONIZE_ISBN'),
         );
+
+        if ($vars['ean'] == 0) {
+            $vars['ean'] = '';
+        }
+        if ($vars['mpn'] == 0) {
+            $vars['mpn'] = '';
+        }
+        if ($vars['upc'] == 0) {
+            $vars['upc'] = '';
+        }
+        if ($vars['isbn'] == 0) {
+            $vars['isbn'] = '';
+        }
 
         $this->smarty->assign($vars);
 
@@ -843,7 +864,7 @@ class EbayRequest
      * configurationValues
      * Getting the rights values selected in the configuration
      *
-     * @param array $data
+     * @param array  $data
      * @param string $type
      * @return string
      */
@@ -881,6 +902,19 @@ class EbayRequest
                 $data['variations'][$key]['upc'] = $this->configurationValues($data['variations'][$key], Configuration::get('EBAY_SYNCHRONIZE_UPC'));
                 $data['variations'][$key]['isbn'] = $this->configurationValues($data['variations'][$key], Configuration::get('EBAY_SYNCHRONIZE_ISBN'));
 
+                if ($data['variations'][$key]['ean13'] == 0) {
+                    $data['variations'][$key]['ean13'] = "";
+                }
+                if ($data['variations'][$key]['mpn'] == 0) {
+                    $data['variations'][$key]['mpn'] = "";
+                }
+                if ($data['variations'][$key]['upc'] == 0) {
+                    $data['variations'][$key]['upc'] = "";
+                }
+                if ($data['variations'][$key]['isbn'] == 0) {
+                    $data['variations'][$key]['isbn'] = "";
+                }
+
                 if (isset($variation['variations'])) {
                     foreach ($variation['variations'] as $variation_key => $variation_element) {
                         if (!isset($attribute_used[md5($variation_element['name'].$variation_element['value'])]) && isset($variation['pictures'][$variation_key])) {
@@ -911,11 +945,15 @@ class EbayRequest
         }
 
         $vars = array(
-            'variations' => isset($data['variations']) ? $data['variations'] : array(),
-            'variations_pictures' => $variation_pictures,
-            'price_update' => !isset($data['noPriceUpdate']),
+            'variations'              => isset($data['variations']) ? $data['variations'] : array(),
+            'variations_pictures'     => $variation_pictures,
+            'price_update'            => !isset($data['noPriceUpdate']),
             'variation_specifics_set' => $variation_specifics_set,
-            'ean_not_applicable' => (int)Configuration::get('EBAY_EAN_NOT_APPLICABLE'),
+            'ean_not_applicable'      => (int)Configuration::get('EBAY_EAN_NOT_APPLICABLE'),
+            'synchronize_ean'         => (string)Configuration::get('EBAY_SYNCHRONIZE_EAN'),
+            'synchronize_mpn'         => (string)Configuration::get('EBAY_SYNCHRONIZE_MPN'),
+            'synchronize_upc'         => (string)Configuration::get('EBAY_SYNCHRONIZE_UPC'),
+            'synchronize_isbn'        => (string)Configuration::get('EBAY_SYNCHRONIZE_ISBN'),
         );
 
         $this->smarty->assign($vars);
@@ -966,7 +1004,7 @@ class EbayRequest
     {
         $vars = array_merge($vars, array(
             'ebay_auth_token' => ($this->ebay_profile ? $this->ebay_profile->getToken() : ''),
-            'error_language' => $this->ebay_country->getLanguage(),
+            'error_language'  => $this->ebay_country->getLanguage(),
         ));
 
         $this->smarty->assign($vars);
@@ -1010,6 +1048,7 @@ class EbayRequest
         // Send the request and get response
         if (stristr($response, 'HTTP 404') || !$response) {
             $this->error = 'Error sending '.$api_call.' request';
+
             return false;
         }
 
@@ -1021,12 +1060,12 @@ class EbayRequest
         $this->error = '';
         $this->errorCode = '';
 
-        if (isset($response->Errors) && isset($response->Ack) && (string) $response->Ack != 'Success' && (string) $response->Ack != 'Warning') {
+        if (isset($response->Errors) && isset($response->Ack) && (string)$response->Ack != 'Success' && (string)$response->Ack != 'Warning') {
             foreach ($response->Errors as $e) {
                 // if product no longer on eBay, we log the error code
-                if ((int) $e->ErrorCode == 291) {
-                    $this->errorCode = (int) $e->ErrorCode;
-                } elseif (in_array((int) $e->ErrorCode, array(21916883, 21916884))) {
+                if ((int)$e->ErrorCode == 291) {
+                    $this->errorCode = (int)$e->ErrorCode;
+                } elseif (in_array((int)$e->ErrorCode, array(21916883, 21916884))) {
                     $this->itemConditionError = true;
                 }
 
@@ -1036,15 +1075,15 @@ class EbayRequest
                         $this->error .= '<br />';
                     }
 
-                    $this->error .= (string) $e->LongMessage;
+                    $this->error .= (string)$e->LongMessage;
 
                     if (isset($e->ErrorParameters->Value)) {
-                        $this->error .= '<br />'.(string) $e->ErrorParameters->Value;
+                        $this->error .= '<br />'.(string)$e->ErrorParameters->Value;
                     }
 
                     if (!Tools::isEmpty($e->ErrorCode)) {
                         $context = Context::getContext();
-                        $this->error .= '<a class="kb-help" data-errorcode="'.(int) $e->ErrorCode.'"';
+                        $this->error .= '<a class="kb-help" data-errorcode="'.(int)$e->ErrorCode.'"';
                         $this->error .= ' data-module="ebay" data-lang="'.$context->language->iso_code.'"';
                         $this->error .= ' module_version="1.11.0" prestashop_version="'._PS_VERSION_.'"></a>';
                     }
@@ -1055,8 +1094,8 @@ class EbayRequest
         // Checking Success
         $this->itemID = 0;
 
-        if (isset($response->Ack) && ((string) $response->Ack == 'Success' || (string) $response->Ack == 'Warning')) {
-            $this->itemID = (string) $response->ItemID;
+        if (isset($response->Ack) && ((string)$response->Ack == 'Success' || (string)$response->Ack == 'Warning')) {
+            $this->itemID = (string)$response->ItemID;
         } elseif (!$this->error) {
             $this->error = 'Sorry, technical problem, try again later.';
         }
@@ -1081,11 +1120,11 @@ class EbayRequest
         $log->response = Tools::jsonEncode($response);
 
         if ($id_product) {
-            $log->id_product = (int) $id_product;
+            $log->id_product = (int)$id_product;
         }
 
         if ($id_order) {
-            $log->id_order = (int) $id_order;
+            $log->id_order = (int)$id_order;
         }
 
         return $log->save();
@@ -1133,6 +1172,6 @@ class EbayRequest
             return false;
         }
 
-        return ((int) $val['id_feature'] == (int) $feature['id_feature'] ? $val['value'] : false);
+        return ((int)$val['id_feature'] == (int)$feature['id_feature'] ? $val['value'] : false);
     }
 }

--- a/classes/EbaySynchronizer.php
+++ b/classes/EbaySynchronizer.php
@@ -34,6 +34,13 @@ class EbaySynchronizer
         return $product['id_product'];
     }
 
+    /**
+     * @param Product     $products
+     * @param Context     $context
+     * @param int     $id_lang
+     * @param null $request_context
+     * @param bool $log_type
+     */
     public static function syncProducts($products, $context, $id_lang, $request_context = null, $log_type = false)
     {
         if (!$products) {
@@ -119,6 +126,10 @@ class EbaySynchronizer
                 'real_id_product' => (int) $p['id_product'],
                 'ebay_store_category_id' => $ebay_store_category_id,
                 'ean_not_applicable' => (int)Configuration::get('EBAY_EAN_NOT_APPLICABLE'),
+                'synchronize_ean'    => (string)Configuration::get('EBAY_SYNCHRONIZE_EAN'),
+                'synchronize_mpn'    => (string)Configuration::get('EBAY_SYNCHRONIZE_MPN'),
+                'synchronize_upc'    => (string)Configuration::get('EBAY_SYNCHRONIZE_UPC'),
+                'synchronize_isbn'   => (string)Configuration::get('EBAY_SYNCHRONIZE_ISBN'),
             );
 
             $data = array_merge($data, EbaySynchronizer::_getProductData($product, $ebay_profile));
@@ -193,6 +204,11 @@ class EbaySynchronizer
         }
     }
 
+    /**
+     * @param Product     $product
+     * @param EbayProfile $ebay_profile
+     * @return array
+     */
     private static function _getProductData($product, $ebay_profile)
     {
         return array(
@@ -298,6 +314,10 @@ class EbaySynchronizer
         return $ebay_category->isMultiSku() && EbaySynchronizer::_hasVariationsMatching($product_id, $id_lang, $ebay_category, $ebay_site_id);
     }
 
+    /**
+     * @param array $variations
+     * @return bool
+     */
     private static function _hasVariationProducts($variations)
     {
         foreach ($variations as $variation) {
@@ -382,6 +402,14 @@ class EbaySynchronizer
         return $tab_error;
     }
 
+    /**
+     * @param Product     $product
+     * @param EbayProfile $ebay_profile
+     * @param int         $id_lang
+     * @param Context     $context
+     * @param array       $variations
+     * @return array
+     */
     public static function _getPictures($product, $ebay_profile, $id_lang, $context, $variations)
     {
         $pictures = array();
@@ -422,6 +450,11 @@ class EbaySynchronizer
         );
     }
 
+    /**
+     * @param Product $product
+     * @param int     $id_product
+     * @return int
+     */
     private static function _getProductQuantity(Product $product, $id_product)
     {
         if (version_compare(_PS_VERSION_, '1.5', '<')) {
@@ -437,7 +470,10 @@ class EbaySynchronizer
     /**
      * Returns the eBay category object. Check if that has been loaded before
      *
-     **/
+     * @param int         $category_id
+     * @param EbayProfile $ebay_profile
+     * @return
+     */
     public static function _getEbayCategory($category_id, $ebay_profile)
     {
         if (!isset(EbaySynchronizer::$ebay_categories[$category_id.'_'.$ebay_profile->id])) {
@@ -447,6 +483,13 @@ class EbaySynchronizer
         return EbaySynchronizer::$ebay_categories[$category_id.'_'.$ebay_profile->id];
     }
 
+    /**
+     * @param Product      $product
+     * @param EbayProfile  $ebay_profile
+     * @param Context      $context
+     * @param EbayCategory $ebay_category
+     * @return array
+     */
     private static function _loadVariations($product, $ebay_profile, $context, $ebay_category)
     {
         $variations = array();
@@ -491,7 +534,7 @@ class EbaySynchronizer
 
             if ($ebay_category->getPercent() < 0) {
                 $variation['price_original'] = round($price_original, 2);
-            } else if ($price_original > $price) {
+            } elseif ($price_original > $price) {
                 $variation['price_original'] = round($price_original, 2);
             }
 
@@ -526,6 +569,14 @@ class EbaySynchronizer
         return $row['id_attribute_group'];
     }
 
+    /**
+     * @param int          $product_id
+     * @param int          $id_lang
+     * @param EbayCategory $ebay_category
+     * @param int          $ebay_site_id
+     * @return bool
+     * @throws PrestaShopDatabaseException
+     */
     private static function _hasVariationsMatching($product_id, $id_lang, $ebay_category, $ebay_site_id)
     {
         $product = new Product($product_id);
@@ -569,6 +620,12 @@ class EbaySynchronizer
         return true;
     }
 
+    /**
+     * @param int         $product_id
+     * @param float       $percent
+     * @param EbayProfile $ebay_profile
+     * @return array
+     */
     private static function _getPrices($product_id, $percent, $ebay_profile)
     {
         $context = clone Context::getContext();
@@ -598,6 +655,12 @@ class EbaySynchronizer
         return array($price, $price_original);
     }
 
+    /**
+     * @param Product     $product
+     * @param EbayProfile $ebay_profile
+     * @param int         $id_lang
+     * @return mixed
+     */
     private static function _getEbayDescription($product, $ebay_profile, $id_lang)
     {
         $features_html = '';
@@ -635,6 +698,15 @@ class EbaySynchronizer
         );
     }
 
+    /**
+     * @param EbayRequest $ebay
+     * @param EbayProfile $ebay_profile
+     * @param Context     $context
+     * @param int         $id_lang
+     * @param int         $ebay_item_id
+     * @param int|null    $product_id
+     * @return EbayRequest
+     */
     public static function endProductOnEbay($ebay, $ebay_profile, $context, $id_lang, $ebay_item_id, $product_id = null)
     {
         if ($product_id) {
@@ -1033,6 +1105,12 @@ class EbaySynchronizer
         return Db::getInstance()->getValue($sql);
     }
 
+    /**
+     * @param EbayCategory $ebay_category
+     * @param Product $product
+     * @param int $id_lang
+     * @return array
+     */
     private static function _getProductItemSpecifics($ebay_category, $product, $id_lang)
     {
         $item_specifics = $ebay_category->getItemsSpecificValues();
@@ -1044,6 +1122,12 @@ class EbaySynchronizer
                 $value = EbaySynchronizer::_getFeatureValue($product->id, $item_specific['id_feature'], $id_lang);
             } elseif ($item_specific['is_brand']) {
                 $value = $product->manufacturer_name;
+            } elseif ($item_specific['is_reference']) {
+                $value = $product->reference;
+            } elseif ($item_specific['is_ean']) {
+                $value = $product->ean13;
+            } elseif ($item_specific['is_upc']) {
+                $value = $product->upc;
             } else {
                 $value = $item_specific['specific_value'];
             }
@@ -1057,6 +1141,12 @@ class EbaySynchronizer
         return $item_specifics_pairs;
     }
 
+    /**
+     * @param int $id_product
+     * @param int $id_attribute_group
+     * @param int $id_lang
+     * @return false|null|string
+     */
     private static function _getAttributeValue($id_product, $id_attribute_group, $id_lang)
     {
         return Db::getInstance()->getValue('SELECT al.`name`
@@ -1072,6 +1162,12 @@ class EbaySynchronizer
 			WHERE al.`id_lang` = '.(int) $id_lang);
     }
 
+    /**
+     * @param int $id_product
+     * @param int $id_feature
+     * @param int $id_lang
+     * @return false|null|string
+     */
     private static function _getFeatureValue($id_product, $id_feature, $id_lang)
     {
         return Db::getInstance()->getValue('SELECT fvl.`value`
@@ -1085,6 +1181,12 @@ class EbaySynchronizer
 			WHERE fvl.`id_lang` = '.(int) $id_lang);
     }
 
+    /**
+     * @param Context $context
+     * @param int $product_id
+     * @param int $quantity
+     * @return int
+     */
     private static function _fixHookUpdateProduct($context, $product_id, $quantity)
     {
         if (isset($context->employee)
@@ -1122,7 +1224,14 @@ class EbaySynchronizer
     /**
      * Returns the item specifics that correspond to a variation and not to the product in general
      *
-     **/
+     * @param int               $product_id
+     * @param int               $product_attribute_id
+     * @param int               $id_lang
+     * @param int               $ebay_site_id
+     * @param EbayCategory|bool $ebay_category
+     * @return array
+     * @throws PrestaShopDatabaseException
+     */
     public static function _getVariationSpecifics($product_id, $product_attribute_id, $id_lang, $ebay_site_id, $ebay_category = false)
     {
         $variation_specifics_pairs = array();
@@ -1160,7 +1269,6 @@ class EbaySynchronizer
         if (version_compare(_PS_VERSION_, '1.5', '>')) {
             Shop::addSqlRestrictionOnLang($alias);
         }
-
     }
 
     private static function _addSqlCheckProductInexistence($alias = null)
@@ -1175,7 +1283,9 @@ class EbaySynchronizer
      * If there is a cover puts it at the top of the list
      * otherwise returns the images in their position order
      *
-     **/
+     * @param array $images
+     * @return array
+     */
     private static function orderImages($images)
     {
         $covers = array();

--- a/classes/EbayValidatorTab.php
+++ b/classes/EbayValidatorTab.php
@@ -18,10 +18,10 @@
  * versions in the future. If you wish to customize PrestaShop for your
  * needs please refer to http://www.prestashop.com for more information.
  *
- *  @author    PrestaShop SA <contact@prestashop.com>
- *  @copyright 2007-2016 PrestaShop SA
- *  @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
- *  International Registered Trademark & Property of PrestaShop SA
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2016 PrestaShop SA
+ * @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
  */
 
 class EbayValidatorTab
@@ -33,26 +33,26 @@ class EbayValidatorTab
         $shipping_national = EbayShipping::getNationalShippings($id_ebay_profile);
         if (!is_array($shipping_national) || count($shipping_national) == 0) {
             return array(
-                'indicator' => 'wrong',
+                'indicator'    => 'wrong',
                 'indicatorBig' => 'wrong',
-                'message' => $ebay->l('You must at least configure one domestic shipping service', 'ebayvalidatortab'),
+                'message'      => $ebay->l('You must at least configure one domestic shipping service', 'ebayvalidatortab'),
             );
         }
 
         $shipping_international = EbayShipping::getInternationalShippings($id_ebay_profile);
         if (!EbayShipping::internationalShippingsHaveZone($shipping_international)) {
             return array(
-                'indicator' => 'wrong',
+                'indicator'    => 'wrong',
                 'indicatorBig' => 'wrong',
-                'message' => $ebay->l('Your international shipping must at least have one zone configured', 'ebayvalidatortab'),
+                'message'      => $ebay->l('Your international shipping must at least have one zone configured', 'ebayvalidatortab'),
             );
         }
 
         if (count($shipping_international) == 0) {
             return array(
-                'indicator' => 'success',
+                'indicator'    => 'success',
                 'indicatorBig' => 'mind',
-                'message' => $ebay->l('You could benefit to configure international shipping services', 'ebayvalidatortab'),
+                'message'      => $ebay->l('You could benefit to configure international shipping services', 'ebayvalidatortab'),
             );
         }
 
@@ -74,9 +74,9 @@ class EbayValidatorTab
             if (($ebay_profile->getConfiguration($config)) == null) {
                 if (!$return_message) {
                     $return_message = array(
-                        'indicator' => 'wrong',
+                        'indicator'    => 'wrong',
                         'indicatorBig' => 'wrong',
-                        'message' => $ebay->l('Your need to configure the field ', 'ebayvalidatortab').' '.$config,
+                        'message'      => $ebay->l('Your need to configure the field ', 'ebayvalidatortab').' '.$config,
                     );
                 }
 
@@ -104,9 +104,9 @@ class EbayValidatorTab
          */
         if (!$ebay_profile->ebay_user_identifier) {
             return array(
-                'indicator' => 'wrong',
+                'indicator'    => 'wrong',
                 'indicatorBig' => 'wrong',
-                'message' => $ebay->l('Your need to configure the field ', 'ebayvalidatortab').' ebay user identifier',
+                'message'      => $ebay->l('Your need to configure the field ', 'ebayvalidatortab').' ebay user identifier',
             );
         }
 
@@ -126,18 +126,18 @@ class EbayValidatorTab
         $ebay = new Ebay();
         if (!EbayCategorySpecific::allMandatorySpecificsAreConfigured($id_ebay_profile)) {
             return array(
-                'indicator' => 'wrong',
+                'indicator'    => 'wrong',
                 'indicatorBig' => 'wrong',
-                'message' => $ebay->l('You need to configure your mandatory items specifics ', 'ebayvalidatortab'),
+                'message'      => $ebay->l('You need to configure your mandatory items specifics ', 'ebayvalidatortab'),
             );
         }
 
         //Check if optional items specifics have been configured
         if (!EbayCategorySpecific::atLeastOneOptionalSpecificIsConfigured($id_ebay_profile)) {
             return array(
-                'indicator' => 'success',
+                'indicator'    => 'success',
                 'indicatorBig' => 'mind',
-                'message' => $ebay->l('You could gain visibility by configuring optional items specifics ', 'ebayvalidatortab'),
+                'message'      => $ebay->l('You could gain visibility by configuring optional items specifics ', 'ebayvalidatortab'),
             );
         }
 
@@ -153,17 +153,17 @@ class EbayValidatorTab
 
         if ($ebay_profile->getConfiguration('EBAY_PRODUCT_TEMPLATE_TITLE') == '') {
             return array(
-                'indicator' => 'wrong',
+                'indicator'    => 'wrong',
                 'indicatorBig' => 'wrong',
-                'message' => $ebay->l('You need to add something in your template title. Use the tags available to personnalize your product title on eBay', 'ebayvalidatortab'),
+                'message'      => $ebay->l('You need to add something in your template title. Use the tags available to personnalize your product title on eBay', 'ebayvalidatortab'),
             );
         }
 
         if ($ebay_profile->getConfiguration('EBAY_PRODUCT_TEMPLATE_TITLE') == '{TITLE}') {
             return array(
-                'indicator' => 'success',
+                'indicator'    => 'success',
                 'indicatorBig' => 'mind',
-                'message' => $ebay->l('You could improve your title template by adding informations about the items', 'ebayvalidatortab'),
+                'message'      => $ebay->l('You could improve your title template by adding informations about the items', 'ebayvalidatortab'),
             );
         }
 
@@ -182,5 +182,4 @@ class EbayValidatorTab
     {
 
     }
-
 }

--- a/classes/TotFormat.php
+++ b/classes/TotFormat.php
@@ -18,9 +18,9 @@
  * versions in the future. If you wish to customize PrestaShop for your
  * needs please refer to http://www.prestashop.com for more information.
  *
- *  @author    PrestaShop SA <contact@prestashop.com>
- *  @copyright 2007-2016 PrestaShop SA
- *  @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2016 PrestaShop SA
+ * @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
  *  International Registered Trademark & Property of PrestaShop SA
  */
 
@@ -117,6 +117,7 @@ class TotFormat
     /**
      * Format product description by removing potential hazardous code
      * @param string $desc description to be cleaned
+     * @return string
      */
     public static function formatDescription($desc)
     {
@@ -131,6 +132,7 @@ class TotFormat
      * This function will take JSON string and indent it very readable.
      *
      * @param string $json to be formatted
+     * @return string
      */
     public static function prettyPrint($json)
     {
@@ -151,9 +153,9 @@ class TotFormat
             }
             if ($in_escape) {
                 $in_escape = false;
-            } else if ($char === '"') {
+            } elseif ($char === '"') {
                 $in_quotes = !$in_quotes;
-            } else if (!$in_quotes) {
+            } elseif (!$in_quotes) {
                 switch ($char) {
                     case '}':
                     case ']':
@@ -182,7 +184,7 @@ class TotFormat
                         $new_line_level = null;
                         break;
                 }
-            } else if ($char === '\\') {
+            } elseif ($char === '\\') {
                 $in_escape = true;
             }
             if ($new_line_level !== null) {

--- a/classes/tabs/EbayFormAdvancedParametersTab.php
+++ b/classes/tabs/EbayFormAdvancedParametersTab.php
@@ -83,6 +83,13 @@ class EbayFormAdvancedParametersTab extends EbayTab
 
         );
 
+        $smarty_vars['help_ean'] = array(
+            'lang'           => $this->context->country->iso_code,
+            'module_version' => $this->ebay->version,
+            'ps_version'     => _PS_VERSION_,
+            'error_code'     => 'HELP-ADV-SETTINGS-EAN',
+        );
+
         return $this->display('formAdvancedParameters.tpl', $smarty_vars);
     }
 

--- a/classes/tabs/EbayFormEbaySyncTab.php
+++ b/classes/tabs/EbayFormEbaySyncTab.php
@@ -38,6 +38,10 @@ class EbayFormEbaySyncTab extends EbayTab
             return '<p class="error"><b>'.$this->ebay->l('Please configure the \'Category settings\' tab before using this tab', 'ebayformebaysynctab').'</b></p><br /><script type="text/javascript">$("#menuTab5").addClass("wrong")</script>';
         }
 
+    	if ( ($minqty = $this->ebay_profile->getConfiguration('EBAY_MINQTY')) == null) {
+    		$minqty = 0;
+    	}
+
         if (version_compare(_PS_VERSION_, '1.5', '>')) {
             $sql = '
 				SELECT COUNT( * ) FROM (
@@ -48,7 +52,7 @@ class EbayFormEbaySyncTab extends EbayTab
 						INNER JOIN  `'._DB_PREFIX_.'product_shop` AS ps
 						ON p.id_product = ps.id_product
 						AND ps.id_shop = '.(int) $this->ebay_profile->id_shop;
-            $sql .= ' WHERE s.`quantity` > 0
+        	$sql .= ' WHERE s.`quantity` > ' . $minqty . '
 						AND  p.`active` = 1
 						AND  p.`id_category_default`
 						IN (
@@ -72,7 +76,7 @@ class EbayFormEbaySyncTab extends EbayTab
 						INNER JOIN  `'._DB_PREFIX_.'product_shop` AS ps
 						ON p.id_product = ps.id_product
 						AND ps.id_shop = '.(int) $this->ebay_profile->id_shop;
-            $sql .= ' WHERE s.`quantity` > 0
+        	$sql .= ' WHERE s.`quantity` > ' . $minqty . '
 						AND  p.`active` = 1
 						AND  p.`id_category_default`
 						IN (
@@ -96,7 +100,7 @@ class EbayFormEbaySyncTab extends EbayTab
 				AND ps.id_shop = '.(int) $this->ebay_profile->id_shop;
             }
 
-            $sql .= ' WHERE p.`quantity` > 0
+        	$sql .= ' WHERE p.`quantity` > ' . $minqty . '
 				AND p.`active` = 1
 				AND p.`id_category_default` IN (
 					SELECT `id_category`
@@ -114,7 +118,7 @@ class EbayFormEbaySyncTab extends EbayTab
 				AND ps.id_shop = '.(int) $this->ebay_profile->id_shop;
             }
 
-            $sql .= ' WHERE p.`quantity` > 0
+        	$sql .= ' WHERE p.`quantity` > ' . $minqty . '
 				AND p.`active` = 1
 				AND p.`id_category_default` IN (
 					SELECT `id_category`

--- a/classes/tabs/EbayFormItemsSpecificsTab.php
+++ b/classes/tabs/EbayFormItemsSpecificsTab.php
@@ -70,7 +70,7 @@ class EbayFormItemsSpecificsTab extends EbayTab
                 }
 
                 $field_names = EbayCategorySpecific::getPrefixToFieldNames();
-                $data = array_combine(array_values($field_names), array(null, null, null, null));
+                $data = array_combine(array_values($field_names), array(null, null, null, null, null, null, null));
 
                 if ($data_type) {
                     $data[$field_names[$data_type]] = pSQL($value);

--- a/classes/tabs/EbayFormParametersTab.php
+++ b/classes/tabs/EbayFormParametersTab.php
@@ -65,6 +65,8 @@ class EbayFormParametersTab extends EbayTab
         $shopPostalCode = Tools::getValue('ebay_shop_postalcode', $this->ebay_profile->getConfiguration('EBAY_SHOP_POSTALCODE'));
         $shopCountry = Tools::getValue('ebay_shop_country', $this->ebay_profile->getConfiguration('EBAY_SHOP_COUNTRY'));
         $ebayListingDuration = $this->ebay_profile->getConfiguration('EBAY_LISTING_DURATION') ? $this->ebay_profile->getConfiguration('EBAY_LISTING_DURATION') : 'GTC';
+    	$ebayMinimumStock = $this->ebay_profile->getConfiguration('EBAY_MINQTY') ? $this->ebay_profile->getConfiguration('EBAY_MINQTY') : '0';
+    	$ebayMaximumQuantity = $this->ebay_profile->getConfiguration('EBAY_MAXQTY') ? $this->ebay_profile->getConfiguration('EBAY_MAXQTY') : '9999';
 
         $user_profile = $ebay_request->getUserProfile($this->ebay_profile->ebay_user_identifier);
 
@@ -95,6 +97,10 @@ class EbayFormParametersTab extends EbayTab
             'ebayShopValue' => $ebayShopValue,
             'shopPostalCode' => Tools::getValue('ebay_shop_postalcode', $this->ebay_profile->getConfiguration('EBAY_SHOP_POSTALCODE')),
             'listingDurations' => $this->_getListingDurations(),
+	        'minimumQuantities' => $this->_getMinimumQuantities(),
+	        'ebayminimumstock' => $ebayMinimumStock,
+	        'ebaymaximumqty' => $ebayMaximumQuantity,
+	        'maximumQuantities' => $this->_getMaximumQuantities(),
             'ebayShop' => $this->ebay_profile->getConfiguration('EBAY_SHOP'),
             'ebay_paypal_email' => Tools::getValue('ebay_paypal_email', $this->ebay_profile->getConfiguration('EBAY_PAYPAL_EMAIL')),
             'returnsConditionAccepted' => Tools::getValue('ebay_returns_accepted_option', $returns_policy_configuration->ebay_returns_accepted_option),
@@ -161,7 +167,9 @@ class EbayFormParametersTab extends EbayTab
             && $this->ebay_profile->setConfiguration('EBAY_SHOP_POSTALCODE', pSQL(Tools::getValue('ebay_shop_postalcode')))
             && $this->ebay_profile->setConfiguration('EBAY_SHOP_COUNTRY', pSQL(Tools::getValue('ebay_shop_country')))
             && $this->ebay_profile->setConfiguration('EBAY_LISTING_DURATION', Tools::getValue('listingdurations'))
-            && $this->ebay_profile->setConfiguration('EBAY_AUTOMATICALLY_RELIST', Tools::getValue('automaticallyrelist'))
+        	&& $this->ebay_profile->setConfiguration('EBAY_MINQTY', (int) Tools::getValue('minimum_stock'))
+        	&& $this->ebay_profile->setConfiguration('EBAY_MAXQTY', (int) Tools::getValue('maximum_quantity'))
+        	&& $this->ebay_profile->setConfiguration('EBAY_AUTOMATICALLY_RELIST', Tools::getValue('automaticallyrelist'))
             && $this->ebay_profile->setReturnsPolicyConfiguration(
                 pSQL(Tools::getValue('returnswithin')),
                 pSQL(Tools::getValue('returnswhopays')),
@@ -201,4 +209,38 @@ class EbayFormParametersTab extends EbayTab
             'GTC' => $this->ebay->l('Good \'Till Canceled'),
         );
     }
+
+	private function _getMinimumQuantities()
+	{
+		return array(
+		    '1' => $this->ebay->l('In stock'),
+		    '2' => $this->ebay->l('2 units'),
+			'3' => $this->ebay->l('3 units'),
+			'5' => $this->ebay->l('5 units'),
+			'10' => $this->ebay->l('10 units'),
+			'50' => $this->ebay->l('50 units'),
+			'100' => $this->ebay->l('100 units'),
+		);
+	}
+
+	private function _getMaximumQuantities()
+	{
+		return array(
+			'100' => $this->ebay->l('100 units'),
+			'50' => $this->ebay->l('50 units'),
+			'10' => $this->ebay->l('10 units'),
+			'5' => $this->ebay->l('5 units'),
+			'3' => $this->ebay->l('3 units'),
+			'2' => $this->ebay->l('2 units'),
+			'1' => $this->ebay->l('1 unit'),
+			'0' => $this->ebay->l('All items'),
+			'-1' => $this->ebay->l('All but 1 unit'),
+			'-2' => $this->ebay->l('All but 2 units'),
+			'-3' => $this->ebay->l('All but 3 units'),
+			'-5' => $this->ebay->l('All but 5 units'),
+			'-10' => $this->ebay->l('All but 10 units'),
+			'-50' => $this->ebay->l('All but 50 units'),
+	);
+	}
+
 }

--- a/classes/tabs/EbayPrestashopProductsTab.php
+++ b/classes/tabs/EbayPrestashopProductsTab.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * 2007-2014 PrestaShop
+ * 2007-2016 PrestaShop
  *
  * NOTICE OF LICENSE
  *
@@ -18,15 +18,14 @@
  * versions in the future. If you wish to customize PrestaShop for your
  * needs please refer to http://www.prestashop.com for more information.
  *
- *  @author    PrestaShop SA <contact@prestashop.com>
- *  @copyright 2007-2016 PrestaShop SA
- *  @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
- *  International Registered Trademark & Property of PrestaShop SA
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2016 PrestaShop SA
+ * @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
  */
 
 class EbayPrestashopProductsTab extends EbayTab
 {
-
     public function getContent()
     {
         $is_one_dot_five = version_compare(_PS_VERSION_, '1.5', '>');
@@ -39,35 +38,20 @@ class EbayPrestashopProductsTab extends EbayTab
         $module_name = Tools::getValue('module_name');
 
         $show_products_url = 'index.php?'.
-        ($is_one_dot_five ? 'controller='.urlencode($controller) : 'tab='.urlencode($tab)).
-        '&configure='.urlencode($configure).'&token='.urlencode($token).
-        '&tab_module='.urlencode($tab_module).
-        '&module_name='.urlencode($module_name).
+            ($is_one_dot_five ? 'controller='.urlencode($controller) : 'tab='.urlencode($tab)).
+            '&configure='.urlencode($configure).'&token='.urlencode($token).
+            '&tab_module='.urlencode($tab_module).
+            '&module_name='.urlencode($module_name).
             '&id_tab=15&section=products';
 
         // Smarty
         $template_vars = array(
-            'id_ebay_profile' => $this->ebay_profile->id,
+            'id_ebay_profile'         => $this->ebay_profile->id,
             'ebay_sync_option_resync' => $this->ebay_profile->getConfiguration('EBAY_SYNC_OPTION_RESYNC'),
-            'show_products_url' => $show_products_url,
-            'id_employee' => Context::getContext()->employee->id,
+            'show_products_url'       => $show_products_url,
+            'id_employee'             => Context::getContext()->employee->id,
         );
 
         return $this->display('prestashop_products.tpl', $template_vars);
     }
-
-/*    public function postProcess()
-{
-
-}*/
-
-    /*
-     *
-     * Get alert to see if some multi variation product on PrestaShop were added to a non multi sku categorie on ebay
-     *
-     */
-/*    private function _getAlertCategories()
-{
-}*/
-
 }

--- a/classes/tabs/EbayTab.php
+++ b/classes/tabs/EbayTab.php
@@ -29,6 +29,7 @@ class EbayTab
     protected $ebay;
     protected $smarty;
     protected $ebay_profile;
+    /** @var Context $context */
     protected $context;
     protected $path;
 

--- a/config.xml
+++ b/config.xml
@@ -2,7 +2,7 @@
 <module>
 	<name>ebay</name>
 	<displayName>eBay</displayName>
-	<version>1.12.2</version>
+	<version>1.12.3</version>
 	<description>Easily export your products from PrestaShop to eBay, the biggest market place, to acquire new customers and realize more sales.</description>
 	<author>PrestaShop</author>
 	<tab>market_place</tab>

--- a/ebay.php
+++ b/ebay.php
@@ -544,6 +544,20 @@ class Ebay extends Module
                 upgrade_module_1_12($this);
             }
         }
+
+        if (version_compare($version, '1.12.2', '<')) {
+            if (version_compare(_PS_VERSION_, '1.5', '<')) {
+                include_once dirname(__FILE__).'/upgrade/Upgrade-1.12.2.php';
+                upgrade_module_1_12_2($this);
+            }
+        }
+
+        if (version_compare($version, '1.12.3', '<')) {
+            if (version_compare(_PS_VERSION_, '1.5', '<')) {
+                include_once dirname(__FILE__).'/upgrade/Upgrade-1.12.3.php';
+                upgrade_module_1_12_3($this);
+            }
+        }
     }
 
     /**

--- a/ebay.php
+++ b/ebay.php
@@ -124,7 +124,7 @@ class Ebay extends Module
     {
         $this->name = 'ebay';
         $this->tab = 'market_place';
-        $this->version = '1.12.2';
+        $this->version = '1.12.3';
         $this->stats_version = '1.0';
 
         $this->author = 'PrestaShop';

--- a/ebay/api/GetProductListingDetails.tpl
+++ b/ebay/api/GetProductListingDetails.tpl
@@ -22,44 +22,17 @@
 *  @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
 *  International Registered Trademark & Property of PrestaShop SA
 *}
-{if ((isset($ean) && $ean != "")
-    || (isset($isbn) && $isbn != "")
-    || (isset($upc) && $upc != "")
-    || (((isset($mpn) && $mpn != "") || isset($sku)) && isset($brand))
-    || (isset($ean) && $ean != ""))
-}
-<ProductListingDetails>
-    {*{if isset($brand) && isset($sku)}*}
-        {*<BrandMPN>*}
-            {*<Brand>{$brand}</Brand>*}
-            {*<MPN>{$sku}</MPN>*}
-        {*</BrandMPN>*}
-    {*{/if}*}
-    {if (isset($mpn) && $mpn != "" && isset($manufacturer_name) && $manufacturer_name != "")}
-    <BrandMPN>
-        <Brand>{$manufacturer_name}</Brand>
-        <MPN>{$mpn}</MPN>
-    </BrandMPN>
-    {/if}
-    {if isset($ean) && $ean != ""}<EAN>{$ean}</EAN>{/if}
-    {*<IncludeeBayProductDetails> boolean </IncludeeBayProductDetails>*}
-    {*<IncludeStockPhotoURL> boolean </IncludeStockPhotoURL>*}
-    {if isset($isbn) && $isbn != ""}<ISBN>{$isbn}</ISBN>{/if}
-    {*<ProductID> string </ProductID>*}
-    {*<ProductReferenceID> string </ProductReferenceID>*}
-    {*<ReturnSearchResultOnDuplicates> boolean </ReturnSearchResultOnDuplicates>*}
-    {*<TicketListingDetails> TicketListingDetailsType*}
-        {*<EventTitle> string </EventTitle>*}
-        {*<PrintedDate> string </PrintedDate>*}
-        {*<PrintedTime> string </PrintedTime>*}
-        {*<Venue> string </Venue>*}
-    {*</TicketListingDetails>*}
-    {if isset($upc) && $upc != ""}<UPC>{$upc}</UPC>{/if}
-    {*<UseFirstProduct> boolean </UseFirstProduct>*}
-    {*<UseStockPhotoURLAsGallery> boolean </UseStockPhotoURLAsGallery>*}
-</ProductListingDetails>
-{elseif isset($ean_not_applicable) && $ean_not_applicable == 1}
-<ProductListingDetails>
-    <EAN>Does not apply</EAN>
-</ProductListingDetails>
+{if (isset($ean_not_applicable) && $ean_not_applicable == 1)}
+    {assign var="does_not_apply" value="Does not apply"}
+{else}
+    {assign var="does_not_apply" value=""}
 {/if}
+<ProductListingDetails>
+    {if ($synchronize_mpn != "")}<BrandMPN>
+        <Brand>{if (isset($manufacturer_name) && $manufacturer_name != "")}{$manufacturer_name}{else}{if ($does_not_apply != "")}Unbranded{/if}{/if}</Brand>
+        <MPN>{if (isset($mpn) && $mpn != "")}{$mpn}{else}{$does_not_apply}{/if}</MPN>
+    </BrandMPN>{/if}
+    {if ($synchronize_ean != "")}<EAN>{if (isset($ean) && $ean != "")}{$ean}{else}{$does_not_apply}{/if}</EAN>{/if}
+    {if ($synchronize_isbn != "")}<ISBN>{if (isset($isbn) && $isbn != "")}{$isbn}{else}{$does_not_apply}{/if}</ISBN>{/if}
+    {if ($synchronize_upc != "")}<UPC>{if (isset($upc) && $upc != "")}{$upc}{else}{$does_not_apply}{/if}</UPC>{/if}
+</ProductListingDetails>

--- a/ebay/api/GetVariations.tpl
+++ b/ebay/api/GetVariations.tpl
@@ -55,19 +55,16 @@
                     <SoldOffeBay>true</SoldOffeBay>
                 </DiscountPriceInfo>
             {/if}
-            {if (isset($variation.ean13) && $variation.ean13 != '')
-			|| (isset($variation.isbn) && $variation.isbn != '')
-			|| (isset($variation.upc) && $variation.upc != '')}
-				<VariationProductListingDetails>
-					{if isset($variation.ean13) && $variation.ean13 != ''}<EAN>{$variation.ean13}</EAN>{/if}
-					{if isset($variation.isbn) && $variation.isbn != ''}<ISBN>{$variation.isbn}</ISBN>{/if}
-					{if isset($variation.upc) && $variation.upc != ''}<UPC>{$variation.upc}</UPC>{/if}
-				</VariationProductListingDetails>
-			{elseif isset($ean_not_applicable) && $ean_not_applicable == 1}
-				<VariationProductListingDetails>
-					<EAN>Does not apply</EAN>
-				</VariationProductListingDetails>
+			{if (isset($ean_not_applicable) && $ean_not_applicable == 1)}
+				{assign var="does_not_apply" value="Does not apply"}
+			{else}
+				{assign var="does_not_apply" value=""}
 			{/if}
+			<VariationProductListingDetails>
+				{if ($synchronize_ean != "")}<EAN>{if isset($variation.ean13) && $variation.ean13 != ''}{$variation.ean13}{else}{$does_not_apply}{/if}</EAN>{/if}
+				{if ($synchronize_isbn != "")}<ISBN>{if isset($variation.isbn) && $variation.isbn != ''}{$variation.isbn}{else}{$does_not_apply}{/if}</ISBN>{/if}
+				{if ($synchronize_upc != "")}<UPC>{if isset($variation.upc) && $variation.upc != ''}{$variation.upc}{else}{$does_not_apply}{/if}</UPC>{/if}
+			</VariationProductListingDetails>
 		</Variation>
 	{/foreach}
 	<Pictures>

--- a/sql/sql-install.php
+++ b/sql/sql-install.php
@@ -176,6 +176,9 @@ $sql[] = 'CREATE TABLE IF NOT EXISTS `'._DB_PREFIX_.'ebay_category_specific` (
 		  `id_ebay_category_specific_value` int(16) NULL,
 		  `is_brand` tinyint(1) NULL,
           `ebay_site_id` int(16) NOT NULL,
+          `is_reference` tinyint(1) NULL,
+          `is_ean` tinyint(1) NULL,
+          `is_upc` tinyint(1) NULL,
 		  UNIQUE(`id_category_ref`, `ebay_site_id`, `name`),
 		  PRIMARY KEY (`id_ebay_category_specific`)
 		) ENGINE='._MYSQL_ENGINE_.' DEFAULT CHARSET=utf8';

--- a/upgrade/Upgrade-1.12.2.php
+++ b/upgrade/Upgrade-1.12.2.php
@@ -35,8 +35,10 @@ function upgrade_module_1_12_2($module)
     }
 
     if ($module->ebay_profile) {
-        $module->ebay_profile->deleteConfigurationByName('EBAY_SPECIFICS_LAST_UPDATE');
+        $module->ebay_profile->setConfiguration('EBAY_SPECIFICS_LAST_UPDATE', null);
     }
+
+    $module->setConfiguration('EBAY_VERSION', $module->version);
 
     return true;
 }

--- a/upgrade/Upgrade-1.12.3.php
+++ b/upgrade/Upgrade-1.12.3.php
@@ -28,15 +28,30 @@
  * @param Ebay $module
  * @return bool
  */
-function upgrade_module_1_12_2($module)
+function upgrade_module_1_12_3($module)
 {
-    if (Configuration::get('EBAY_SYNCHRONIZE_EAN')) {
-        $module->setConfiguration('EBAY_SYNCHRONIZE_EAN', 'EAN');
+    $sql = sql_1_12_3();
+    if (!empty($sql) && is_array($sql)) {
+        foreach ($sql as $request) {
+            if (!Db::getInstance()->execute($request)) {
+                return false;
+            }
+        }
     }
 
     if ($module->ebay_profile) {
-        $module->ebay_profile->deleteConfigurationByName('EBAY_SPECIFICS_LAST_UPDATE');
+        $module->ebay_profile->setConfiguration('EBAY_SPECIFICS_LAST_UPDATE', null);
     }
 
     return true;
+}
+
+function sql_1_12_3()
+{
+    $sql = array();
+    $sql[] = 'ALTER TABLE `'._DB_PREFIX_.'ebay_category_specific` ADD `is_reference` tinyint(1) NULL';
+    $sql[] = 'ALTER TABLE `'._DB_PREFIX_.'ebay_category_specific` ADD `is_ean` tinyint(1) NULL';
+    $sql[] = 'ALTER TABLE `'._DB_PREFIX_.'ebay_category_specific` ADD `is_upc` tinyint(1) NULL';
+
+    return $sql;
 }

--- a/upgrade/Upgrade-1.12.3.php
+++ b/upgrade/Upgrade-1.12.3.php
@@ -43,6 +43,8 @@ function upgrade_module_1_12_3($module)
         $module->ebay_profile->setConfiguration('EBAY_SPECIFICS_LAST_UPDATE', null);
     }
 
+    $module->setConfiguration('EBAY_VERSION', $module->version);
+
     return true;
 }
 

--- a/views/js/itemsSpecifics.js
+++ b/views/js/itemsSpecifics.js
@@ -78,18 +78,24 @@ function insertCategoryRow(category_id, data)
 		{
 			if (!data.is_multi_sku || specific.can_variation)
 			{
-				tds += '<option disabled="disabled">' + l['Attributes'] + '</option>';
-				tds += writeOptions('attr', possible_attributes, specific.id_attribute_group);		
+				tds += '<optgroup label="' + l['Attributes'] + '">';
+				tds += writeOptions('attr', possible_attributes, specific.id_attribute_group);
+				tds += '</optgroup>';
 			}
-			
-			tds += '<option disabled="disabled">' + l['Features'] + '</option>';
+			tds += '<optgroup label="' + l['Product Attributes'] + '">';
 			tds += '<option value="brand-1" ' + (specific.is_brand == 1 ? 'selected' : '') + '>' + l['Brand'] + '</option>';
+			tds += '<option value="reference-1" ' + (specific.is_reference == 1 ? 'selected' : '') + '>' + l['Reference'] + '</option>';
+			tds += '<option value="ean-1" ' + (specific.is_ean == 1 ? 'selected' : '') + '>' + l['EAN'] + '</option>';
+			tds += '<option value="upc-1" ' + (specific.is_upc == 1 ? 'selected' : '') + '>' + l['UPC'] + '</option>';
+			tds += '</optgroup>';
+			tds += '<optgroup label="' + l['Features'] + '">';
 			tds += writeOptions('feat', possible_features, specific.id_feature);
+			tds += '</optgroup>';
 		}
 
-		tds += '<option disabled="disabled">' + l['eBay Specifications'] + '</option>';
+		tds += '<optgroup label="' + l['eBay Specifications'] + '">';
 		tds += writeOptions('spec', specific.values, specific.id_specific_value);
-		
+		tds += '</optgroup>';
 		tds += '</select></td>';
 
 		if (parseInt(specific.required))

--- a/views/js/jquery.noConflict.php
+++ b/views/js/jquery.noConflict.php
@@ -1,4 +1,5 @@
-<?php 
+<?php
 header('content-type: application/x-javascript');
-if (preg_match('/^([0-9]+\.)+[0-9]$/Ui', $_GET['version']))
-	echo 'var $j'.str_replace('.', '', $_GET['version']).' = jQuery.noConflict(true);';
+if (preg_match('/^([0-9]+\.)+[0-9]$/Ui', $_GET['version'])) {
+    echo 'var $j'.str_replace('.', '', $_GET['version']).' = jQuery.noConflict(true);';
+}

--- a/views/templates/hook/formAdvancedParameters.tpl
+++ b/views/templates/hook/formAdvancedParameters.tpl
@@ -127,7 +127,7 @@
     
     <fieldset style="margin-top:10px;">
        
-        <legend>{l s='EAN Sync' mod='ebay'}</legend>
+        <legend>{l s='EAN Sync' mod='ebay'} <a class="kb-help" data-errorcode="{$help_ean.error_code}" data-module="ebay" data-lang="{$help_ean.lang}" module_version="{$help_ean.module_version}" prestashop_version="{$help_ean.ps_version}" href="" target="_blank"></a></legend>
 
 		<label>{l s='Synchronize EAN with :' mod='ebay'}</label>
 		<div class="margin-form">

--- a/views/templates/hook/formItemsSpecifics.tpl
+++ b/views/templates/hook/formItemsSpecifics.tpl
@@ -72,13 +72,17 @@
 	var id_lang = "{$id_lang|escape:'htmlall':'UTF-8'}";
     var id_ebay_profile = "{$id_ebay_profile|escape:'htmlall':'UTF-8'}";
 	var ebay_token = "{$ebay_token|escape:'htmlall':'UTF-8'}";
-	
+
 	var l = {ldelim}
 		'Attributes'						: "{l s='Attributes' mod='ebay'}",
 		'Features'							: "{l s='Features' mod='ebay'}",
 		'eBay Specifications'				: "{l s='eBay Specifications' mod='ebay'}",
 		'Brand'								: "{l s='Brand' mod='ebay'}",
-		'-- You have to select a value --'	: "{l s='-- You have to select a value --' mod='ebay'}"
+		'-- You have to select a value --'	: "{l s='-- You have to select a value --' mod='ebay'}",
+		'Product Attributes'				: "{l s='Product Attributes' mod='ebay'}",
+		'Reference'							: "{l s='Reference' mod='ebay'}",
+		'EAN'								: "{l s='EAN' mod='ebay'}",
+		'UPC'								: "{l s='UPC' mod='ebay'}",
 	{rdelim};
 
 	var categories_to_load = new Array();

--- a/views/templates/hook/formParameters.tpl
+++ b/views/templates/hook/formParameters.tpl
@@ -28,7 +28,7 @@
 	<script>
 		$(document).ready(function() {
 			win = window.location = '{/literal}{$redirect_url|escape:'urlencode'}{literal}';
-		});		
+		});
 	</script>
 	{/literal}
 {/if}
@@ -54,25 +54,25 @@
 	{if isset($check_token_tpl)}
 	<fieldset id="regenerate_token">
 		<legend>{l s='Token' mod='ebay'}</legend>
-			{$check_token_tpl}	
-	</fieldset>	
+			{$check_token_tpl}
+	</fieldset>
 	{/if}
-	
+
 <form action="{$url|escape:'urlencode'}" method="post" class="form" id="configForm1">
-    
+
 	<fieldset style="margin-top:10px;">
 		<legend>{l s='Account details' mod='ebay'}</legend>
 		<h4>{l s='To list your products on eBay, you need to create' mod='ebay'} <a href="https://www.paypal.com/" target="_blank">{l s='a PayPal account.' mod='ebay'}</a></h4>
-        
-		<input type="hidden" name="ebay_shop" value="{$ebayShopValue|escape:'htmlall':'UTF-8'}" />            
-        
+
+		<input type="hidden" name="ebay_shop" value="{$ebayShopValue|escape:'htmlall':'UTF-8'}" />
+
 		<label>{l s='Paypal email address' mod='ebay'} : </label>
 		<div class="margin-form">
 
 			<input type="text" size="20" name="ebay_paypal_email" value="{$ebay_paypal_email|escape:'htmlall':'UTF-8'}"/>
 			<p>{l s='You have to set your PayPal e-mail account, it\'s the only payment available with this module' mod='ebay'}<a class="kb-help" data-errorcode="{$help.code_payment_solution}" data-module="ebay" data-lang="{$help.lang}" module_version="{$help.module_version}" prestashop_version="{$help.ps_version}" href="" target="_blank"></a></p>
 		</div>
-        
+
 		<label>
 			{l s='Currency' mod='ebay'}
 		</label>
@@ -84,8 +84,8 @@
 					{/foreach}
 				{/if}
 			</select>
-		</div>        
-        
+		</div>
+
 		<label>{l s='Item location' mod='ebay'} : </label>
 		<div class="margin-form">
 			<input type="text" size="20" name="ebay_shop_postalcode" value="{$shopPostalCode|escape:'htmlall':'UTF-8'}"/>
@@ -97,16 +97,16 @@
                 <option value=""></option>
 			{foreach from=$ebay_shop_countries item=ebay_shop_country}
 				<option value="{$ebay_shop_country.iso_code|escape:'htmlall':'UTF-8'}" {if $current_ebay_shop_country == $ebay_shop_country.iso_code} selected="selected"{/if}>{$ebay_shop_country.site_name|escape:'htmlall':'UTF-8'}</option>
-			{/foreach}							   
-			</select>            
+			{/foreach}
+			</select>
 			<p>{l s='Your shop\'s country' mod='ebay'}</p>
-		</div>     
+		</div>
 		<label>
 			{l s='Immediate Payment' mod='ebay'}
 		</label>
 		<div class="margin-form">
 			<input type="checkbox" name="immediate_payment" value="1"{if $immediate_payment} checked="checked"{/if}>
-		</div>           
+		</div>
 
 		<div class="show regenerate_token_click" style="display:block;text-align:center;cursor:pointer">
 			<span data-inlinehelp="{l s='Use only if you get a message saying that your authentication is expired.' mod='ebay'}">{l s='Click here to generate a new authentication token.' mod='ebay'}</span>
@@ -118,7 +118,7 @@
 			</a>
 		</div>
 	</fieldset>
-        
+
    <fieldset style="margin-top:10px;">
 		<legend>{l s='Returns policy' mod='ebay'}</legend>
 		<label>{l s='Please define your returns policy' mod='ebay'} : </label>
@@ -126,7 +126,7 @@
 			<select name="ebay_returns_accepted_option" data-dialoghelp="#returnsAccepted" data-inlinehelp="{l s='eBay business sellers must accept returns under the Distance Selling Regulations.' mod='ebay'}" class="ebay_select">
 			{foreach from=$policies item=policy}
 				<option value="{$policy.value|escape:'htmlall':'UTF-8'}" {if $returnsConditionAccepted == $policy.value} selected="selected"{/if}>{$policy.description|escape:'htmlall':'UTF-8'}</option>
-			{/foreach}							   
+			{/foreach}
 			</select>
 		</div>
 		<div style="clear:both;"></div>
@@ -156,8 +156,8 @@
 			<textarea name="ebay_returns_description" cols="120" rows="10" data-inlinehelp="{l s='This description will be displayed in the returns policy section of the listing page.' mod='ebay'}">{$ebayReturns|escape:'htmlall':'UTF-8'}</textarea>
 		</div>
 	</fieldset>
-             
-	
+
+
     <fieldset style="margin-top:10px;">
  		<legend>{l s='Order Synchronization from PrestaShop to eBay' mod='ebay'}</legend>
 		<label>
@@ -166,7 +166,7 @@
 		<div class="margin-form">
 			<input type="checkbox" name="send_tracking_code" value="1"{if $send_tracking_code} checked="checked"{/if}>
 		</div>
-        
+
 		<label>
 			{l s='Status used to indicate product has been shipped' mod='ebay'}
 		</label>
@@ -179,16 +179,16 @@
 					{/foreach}
 				{/if}
 			</select>
-		</div>        
-        
+		</div>
+
  		<div style="clear:both;"></div>
-     </fieldset>    
-     
-     
+     </fieldset>
+
+
 	<!-- Listing Durations -->
 	<fieldset style="margin-top:10px;">
 		<legend>{l s='Listing Duration' mod='ebay'}</legend>
-		
+
 		<label>
 			{l s='Listing duration' mod='ebay'}
 		</label>
@@ -200,12 +200,35 @@
 				{/foreach}
 			</select>
 		</div>
-		
+
         <label for="">{l s='Do you want to automatically relist' mod='ebay'}</label>
 		<div class="margin-form"><input type="checkbox" name="automaticallyrelist" {if $automaticallyRelist == 'on'} checked="checked" {/if} /></div>
+
+		<label>
+			{l s='Mimumum stock before sending to eBay' mod='ebay'}
+		</label>
+		<div class="margin-form">
+			<select name="minimum_stock" data-dialoghelp="{l s='http://pages.ebay.com/help/sell/duration.html' mod='ebay'}" data-inlinehelp="{l s='The minimum stock holding necessary before a listing will be created on eBay.' mod='ebay'}" class="ebay_select">
+				{foreach from=$minimumQuantities item=listing key=key}
+					<option value="{$key|escape:'htmlall':'UTF-8'}" {if $ebayminimumstock == $key}selected="selected" {/if}>{$listing|escape:'htmlall':'UTF-8'}</option>
+				{/foreach}
+			</select>
+		</div>
+
+		<label>
+			{l s='Maximum quantity to list on eBay' mod='ebay'}
+		</label>
+		<div class="margin-form">
+			<select name="maximum_quantity" data-dialoghelp="{l s='http://pages.ebay.com/help/sell/duration.html' mod='ebay'}" data-inlinehelp="{l s='The maximum quantity to be listed on eBay.' mod='ebay'}" class="ebay_select">
+				{foreach from=$maximumQuantities item=listing key=key}
+					<option value="{$key|escape:'htmlall':'UTF-8'}" {if $ebaymaximumqty == $key}selected="selected" {/if}>{$listing|escape:'htmlall':'UTF-8'}</option>
+				{/foreach}
+			</select>
+		</div>
+
 	</fieldset>
-    
-        
+
+
 	<div class="margin-form" id="buttonEbayParameters" style="margin-top:5px;">
 		<a href="#categoriesProgression" {if $catLoaded}id="displayFancybox"{/if}>
 			<input class="primary button" name="submitSave" type="hidden" value="{l s='Save and continue' mod='ebay'}" />


### PR DESCRIPTION
This adds two configuration fields to the ebay profile.
A minimum quantity - products with stock levels below this quantity will not be uploaded.
A maximum quantity - quantity available for sale on ebay will be limited to this value.

Rationale - to limit exposure to overselling when products are listed in multiple marketplaces, and delays in synchronisation can cause items to still be on sale on eBay after being sold elsewhere.
